### PR TITLE
Workaround to render the correct chat message time

### DIFF
--- a/src/components/chat/message.js
+++ b/src/components/chat/message.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { FormattedTime } from 'react-intl';
 import Linkify from 'linkifyjs/react';
 import cx from 'classnames';
 import {
@@ -9,6 +8,22 @@ import {
 import './index.scss';
 
 export default class Message extends Component {
+  constructor(props) {
+    super(props);
+
+    const options = {
+      hourCycle: 'h23',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      timeZone: 'UTC',
+    };
+
+    // TODO: As soon as react-int fixes FormattedTime
+    // this should come back as it were before
+    this.timeFormatter = new Intl.DateTimeFormat('default', options);
+  }
+
   shouldComponentUpdate(nextProps) {
     const { active } = this.props;
 
@@ -55,6 +70,7 @@ export default class Message extends Component {
     } = this.props;
 
     const milliseconds = getTimestampAsMilliseconds(timestamp);
+    const time = this.timeFormatter.format(milliseconds);
 
     return (
       <div className="data">
@@ -63,14 +79,7 @@ export default class Message extends Component {
             {name}
           </div>
           <div className={cx('time', { inactive: !active })}>
-            <FormattedTime
-              hour12={false}
-              hour='numeric'
-              minute='numeric'
-              second='numeric'
-              timeZone='UTC'
-              value={milliseconds}
-            />
+            {time}
           </div>
         </div>
         <div className={cx('text', { inactive: !active })}>


### PR DESCRIPTION
Looks like since Chrome 80 you must force `timeCycle=h23` to avoid displaying midnight as `24:00:00`. Since we localize the chat message time and force it to be something like epoch zero to higher Chrome starting zero was being displayed as `24:00:00`. It could be an easy fix if `react-intl` didn't had this issue active https://github.com/formatjs/formatjs/issues/1577.

While `FormattedTime` isn't handling `timeCycle` correctly we will be setting `Intl` manually. I'll add a new issue to track `react-intl` changes so we can update and revert this change in the future.