### PR TITLE
Playback title including record name

### DIFF
--- a/src/components/bars/index.scss
+++ b/src/components/bars/index.scss
@@ -7,12 +7,12 @@
   grid-area: navigation-bar;
 
   .title {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
     color: white;
     font-weight: $font-weight-light;
-    overflow: hidden;
     padding: $padding-small;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   .button-wrapper {

--- a/src/components/bars/navigation.js
+++ b/src/components/bars/navigation.js
@@ -22,15 +22,24 @@ export default class NavigationBar extends PureComponent {
     const {
       epoch,
       name,
+      recordName,
     } = this.props;
 
     const date = <FormattedDate value={new Date(epoch)} />;
 
+    if (!recordName) {
     return (
       <span className="title">
         {name} - {date}
       </span>
     );
+    } else {
+      return (
+        <span className="title">
+          {recordName} - {name} - {date}
+        </span>
+      );
+    }
   }
 
   render() {

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -156,12 +156,14 @@ export default class Player extends PureComponent {
     const {
       epoch,
       name,
+      recordName,
     } = this.metadata;
 
     return (
       <NavigationBar
         epoch={epoch}
         name={name}
+        recordName={recordName}
         section={section}
         toggleSection={() => this.toggleSection()}
       />

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -74,9 +74,15 @@ const buildMetadata = result => {
 
     const epoch = parseInt(recording.start_time.shift(), 10);
 
+    var recordName;
+    if (recording.meta[0].name) {
+      recordName = recording.meta[0].name[0];
+    }
+
     data = {
       id,
       name,
+      recordName,
       epoch,
     };
   }


### PR DESCRIPTION
Working on the issue #31 ,I implemented a solution to show the title "[record (lecture) name] - [meeting room name] - [date]", which I think more informative for students. If the room owner does not put the record name, the title remains to be "[meeting room name] - [date]".

This change may produce a much longer title. For this, I remove the restriction of single line, showing maximum two lines by using webkit fuction, which seems to work in Chrome and Firefox in PC and Android. I am pretty sure it works also in Safari. 