### PR TITLE
Add support for creating self-contained recording playback packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ https://<domain>/playback/presentation/2.3/<recordId>
 - video: primary media configuration
   - `fps`: frames per second
   - `rates`: speed rates
+
+## Standalone recordings
+
+bbb-playback can be used to create a self-contained recording - a single directory that contains all of the recording media files as well as the playback html and javascript code. To do this, use the following build command:
+```
+PUBLIC_URL=. REACT_APP_NO_ROUTER=1 npm run-script build
+```
+And then copy all of the files from the bbb-playback `build` directory and the files from `/var/bigbluebutton/published/presentation/<recordid>` together into a single directory.

--- a/src/components/loader.js
+++ b/src/components/loader.js
@@ -8,6 +8,7 @@ import Error from './error';
 import Player from './player';
 import { build } from 'utils/builder';
 import {
+  buildFileURL,
   getFileName,
   getFileType,
   getLayout,
@@ -59,7 +60,7 @@ class Loader extends PureComponent {
   }
 
   fetchFile(recordId, file) {
-    const url = `/presentation/${recordId}/${file}`;
+    const url = buildFileURL(recordId, file);
     fetch(url).then(response => {
       if (response.ok) {
         logger.debug('loader', file, response);
@@ -89,7 +90,7 @@ class Loader extends PureComponent {
 
   fetchMedia() {
     const fetches = config.medias.map(type => {
-      const url = `/presentation/${this.recordId}/video/webcams.${type}`;
+      const url = buildFileURL(this.recordId, `video/webcams.${type}`);
       return fetch(url, { method: 'HEAD' });
     });
 

--- a/src/components/presentation/canvas.js
+++ b/src/components/presentation/canvas.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import { buildFileURL } from 'utils/data';
 import './index.scss';
 
 export default class Canvas extends PureComponent {
@@ -7,7 +8,7 @@ export default class Canvas extends PureComponent {
 
     const { metadata } = props;
 
-    this.url = `/presentation/${metadata.id}`;
+    this.recordId = metadata.id;
   }
 
   renderPolyline(style, data) {
@@ -88,7 +89,7 @@ export default class Canvas extends PureComponent {
           transform={image.transform}
           width={image.width}
           x={image.x}
-          href={`${this.url}/${image['xlink:href']}`}
+          href={buildFileURL(this.recordId, image['xlink:href'])}
           y={image.y}
         />
       </g>

--- a/src/components/presentation/slide.js
+++ b/src/components/presentation/slide.js
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import { buildFileURL } from 'utils/data';
 import './index.scss';
 
 export default class Slide extends PureComponent {
@@ -7,7 +8,7 @@ export default class Slide extends PureComponent {
 
     const { metadata } = props;
 
-    this.url = `/presentation/${metadata.id}`;
+    this.recordId = metadata.id;
   }
 
   getProxy(id, height, width) {
@@ -26,7 +27,7 @@ export default class Slide extends PureComponent {
         <img
           alt={thumbnail.alt}
           className="proxy"
-          src={`${this.url}/${thumbnail.src}`}
+          src={buildFileURL(this.recordId, thumbnail.src)}
         />
       </foreignObject>
     );
@@ -52,7 +53,7 @@ export default class Slide extends PureComponent {
         {this.getProxy(id, height, width)}
         <image
           height={height}
-          href={`${this.url}/${src}`}
+          href={buildFileURL(this.recordId, src)}
           x={0}
           width={width}
           y={0}

--- a/src/components/router.js
+++ b/src/components/router.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { error } from 'config';
+import Error from 'components/error';
+import Loader from './loader';
+
+const Router = () => {
+  return (
+    <BrowserRouter basename={process.env.PUBLIC_URL}>
+      <Switch>
+        <Route
+          path="/:recordId"
+          component={Loader}
+        />
+        <Route render={(props) => <Error {...props} code={error['NOT_FOUND']} />} />
+      </Switch>
+    </BrowserRouter>
+  );
+}
+
+export default Router;

--- a/src/components/screenshare/index.js
+++ b/src/components/screenshare/index.js
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { defineMessages } from 'react-intl';
 import cx from 'classnames';
 import videojs from 'video.js';
+import { buildFileURL } from 'utils/data';
 import './index.scss';
 
 const intlMessages = defineMessages({
@@ -20,14 +21,12 @@ export default class Screenshare extends PureComponent {
       metadata,
     } = props;
 
-    const url = `/presentation/${metadata.id}`;
-
     const sources = [
       {
-        src: `${url}/deskshare/deskshare.mp4`,
+        src: buildFileURL(metadata.id, 'deskshare/deskshare.mp4'),
         type: `video/mp4`,
       }, {
-        src: `${url}/deskshare/deskshare.webm`,
+        src: buildFileURL(metadata.id, 'deskshare/deskshare.webm'),
         type: `video/webm`,
       },
     ].filter(src => {

--- a/src/components/thumbnails/index.js
+++ b/src/components/thumbnails/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import cx from 'classnames';
 import { defineMessages } from 'react-intl';
 import { thumbnails as config } from 'config';
-import { getScrollTop } from 'utils/data';
+import { getScrollTop, buildFileURL } from 'utils/data';
 import './index.scss';
 
 const SCREENSHARE = 'deskshare';
@@ -21,7 +21,7 @@ export default class Thumbnails extends Component {
     const { metadata } = props;
 
     this.id = 'thumbnails';
-    this.url = `/presentation/${metadata.id}`;
+    this.recordId = metadata.id;
   }
 
   componentDidMount() {
@@ -103,7 +103,7 @@ export default class Thumbnails extends Component {
         className={cx('thumbnail', { active })}
         onClick={onClick}
         onKeyPress={(e) => e.key === 'Enter' ? onClick() : null}
-        src={`${this.url}/${src}`}
+        src={buildFileURL(this.recordId, src)}
         tabIndex="0"
       />
     );

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -3,6 +3,7 @@ import { defineMessages } from 'react-intl';
 import videojs from 'video.js';
 import 'utils/videojs';
 import { video as config } from 'config';
+import { buildFileURL } from 'utils/data';
 import './index.scss';
 
 const intlMessages = defineMessages({
@@ -22,14 +23,12 @@ export default class Video extends PureComponent {
       metadata,
     } = props;
 
-    const url = `/presentation/${metadata.id}`;
-
     const sources = [
       {
-        src: `${url}/video/webcams.mp4`,
+        src: buildFileURL(metadata.id, 'video/webcams.mp4'),
         type: 'video/mp4',
       }, {
-        src: `${url}/video/webcams.webm`,
+        src: buildFileURL(metadata.id, 'video/webcams.webm'),
         type: 'video/webm',
       },
     ].filter(src => {
@@ -44,11 +43,9 @@ export default class Video extends PureComponent {
         localeName,
       } = lang;
 
-      const src = `/presentation/${metadata.id}/caption_${locale}.vtt`;
-
       return {
         kind: 'captions',
-        src,
+        src: buildFileURL(metadata.id, `caption_${locale}.vtt`),
         srclang: locale,
         label: localeName,
       };

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { IntlProvider } from "react-intl";
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
-import { error } from 'config';
-import Error from 'components/error';
 import Loader from 'components/loader';
+import Router from 'components/router';
 import {
   getLocale,
   getMessages,
 } from 'locales';
+import { LOCAL } from 'utils/data';
 import './index.scss';
 
 const locale = getLocale();
@@ -20,15 +19,7 @@ ReactDOM.render(
       locale={locale}
       messages={messages[locale]}
     >
-      <BrowserRouter basename={process.env.PUBLIC_URL}>
-        <Switch>
-          <Route
-            path="/:recordId"
-            component={ Loader }
-          />
-          <Route render={(props) => <Error {...props} code={error['NOT_FOUND']} />} />
-        </Switch>
-      </BrowserRouter>
+      {LOCAL ? <Loader /> : <Router />}
     </IntlProvider>
   ),
   document.getElementById('root')

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -3,12 +3,22 @@ import qs from 'qs';
 import stringHash from 'string-hash';
 import logger from './logger';
 
+const LOCAL = process.env.REACT_APP_NO_ROUTER;
+
 const MEDIA = 'media';
 const CONTENT = 'content';
 const DISABLED = 'disabled';
 
 const PRESENTATION = 'presentation';
 const SCREENSHARE = 'screenshare';
+
+const buildFileURL = (recordId, file) => {
+  if (LOCAL) {
+    return file;
+  } else {
+    return `/presentation/${recordId}/${file}`;
+  }
+};
 
 const getAvatarColor = name => {
   const { avatar } = config.colors;
@@ -116,6 +126,11 @@ const getLayout = location => {
 };
 
 const getRecordId = match => {
+  if (LOCAL) {
+    logger.debug('local', 'recordId');
+    return 'local';
+  }
+
   if (match) {
     const { params } = match;
     if (params && params.recordId) {
@@ -378,6 +393,8 @@ const search = (text, data) => {
 const wasCleared = (time, clear) => clear !== -1 && clear <= time;
 
 export {
+  LOCAL,
+  buildFileURL,
   getAvatarColor,
   getActiveContent,
   getControlFromLayout,


### PR DESCRIPTION
This adds a build option REACT_APP_NO_ROUTER that removes the code to
read the recordId from the URL. When used in combination with
PUBLIC_URL=. it will load all resources from the current directory. With
this setup, you can put the playback files and recording media files
together into a single directory for a self-contained recording.