### PR TITLE
Remove the crossorigin attribute on video tags

### DIFF
--- a/src/components/screenshare/index.js
+++ b/src/components/screenshare/index.js
@@ -72,7 +72,6 @@ export default class Screenshare extends PureComponent {
         <div data-vjs-player>
           <video
             className="video-js"
-            crossOrigin="anonymous"
             playsInline
             preload="auto"
             ref={node => this.node = node}

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -123,7 +123,6 @@ export default class Video extends PureComponent {
         <div data-vjs-player>
           <video
             className="video-js"
-            crossOrigin="anonymous"
             playsInline
             preload="auto"
             ref={node => this.node = node}


### PR DESCRIPTION
The crossorigin attribute isn't required for the normal case of loading
video from the same domain. And Safari (both desktop and iOS) have a bug
when crossOrigin="anonymous" is used that cause it to remove
authentication cookies on same-origin requests! Removing the attribute
works around that issue.