### PR TITLE
Use the "core" version of video.js

### DIFF
--- a/src/components/screenshare/index.js
+++ b/src/components/screenshare/index.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { defineMessages } from 'react-intl';
 import cx from 'classnames';
-import videojs from 'video.js';
+import videojs from 'video.js/core.es.js';
 import { buildFileURL } from 'utils/data';
 import './index.scss';
 

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { defineMessages } from 'react-intl';
-import videojs from 'video.js';
+import videojs from 'video.js/core.es.js';
 import 'utils/videojs';
 import { video as config } from 'config';
 import { buildFileURL } from 'utils/data';

--- a/src/utils/videojs/marker.js
+++ b/src/utils/videojs/marker.js
@@ -1,4 +1,4 @@
-import videojs from 'video.js';
+import videojs from 'video.js/core.es.js';
 import { isValid } from 'utils/data';
 import './index.scss';
 


### PR DESCRIPTION
Current versions of video.js include the "HTTP Streaming" plugin by
default, which adds support for HLS and DASH format videos. Since we
aren't actually using those, we can instead import only the video.js
core features.

This reduces the size of the built javascript by ~78KB with no loss of
functionality. (vtt.js is still included for caption support)