### PR TITLE
Add new design

### DIFF
--- a/src/components/bars/action.js
+++ b/src/components/bars/action.js
@@ -75,7 +75,7 @@ export default class ActionBar extends Component {
         aria={intl.formatMessage(intlMessages.thumbnails)}
         handleOnClick={toggleThumbnails}
         icon="rooms"
-        type="ghost"
+        type="solid"
       />
     );
   }
@@ -97,10 +97,10 @@ export default class ActionBar extends Component {
     return (
       <div className="action-bar">
         <div className="left">
-          {control && search && presentation ? this.renderSearchButton() : null}
+          {control && swap ? this.renderSwapButton() : null}
         </div>
         <div className="center">
-          {control && swap ? this.renderSwapButton() : null}
+          {control && search && presentation ? this.renderSearchButton() : null}
         </div>
         <div className="right">
           {control && thumbnails && presentation ? this.renderThumbnailsButton(): null}

--- a/src/components/bars/index.scss
+++ b/src/components/bars/index.scss
@@ -5,8 +5,7 @@
   grid-area: navigation-bar;
 
   .title {
-    color: white;
-    font-weight: var(--font-weight-light);
+    color: var(--title-color);
     overflow: hidden;
     padding: $padding-small;
     text-overflow: ellipsis;

--- a/src/components/bars/navigation.js
+++ b/src/components/bars/navigation.js
@@ -43,7 +43,7 @@ export default class NavigationBar extends PureComponent {
       <Button
         aria={intl.formatMessage(intlMessages.section)}
         handleOnClick={toggleSection}
-        icon={section ? 'minus' : 'plus'}
+        icon={section ? 'left-arrow' : 'right-arrow'}
       />
     );
   }

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -84,7 +84,7 @@ $error-font-size: 5rem;
 
   div {
     animation: dots 1.4s infinite ease-in-out both;
-    background-color: var(--white);
+    background-color: var(--gray);
     border-radius: 100%;
     display: inline-block;
     height: $loading-dot-size;

--- a/src/components/utils/button/index.scss
+++ b/src/components/utils/button/index.scss
@@ -14,12 +14,12 @@ $button-size: 2.75rem;
     font-size: large;
     height: $button-size;
     width: $button-size;
-    color: var(--white);
   }
 
   .default {
     background-color: transparent;
     border: none;
+    color: var(--gray);
 
     &:focus {
       box-shadow: 0 0 0 $margin-extra-small;
@@ -29,6 +29,7 @@ $button-size: 2.75rem;
   .solid {
     background-color: var(--button-color);
     border: none;
+    color: var(--white);
 
     &:focus {
       box-shadow: 0 0 0 $margin-extra-small var(--button-color);
@@ -38,6 +39,7 @@ $button-size: 2.75rem;
   .ghost {
     background-color: transparent;
     border: solid;
+    color: var(--gray);
 
     &:focus {
       box-shadow: 0 0 0 $margin-extra-small;
@@ -47,6 +49,7 @@ $button-size: 2.75rem;
   .disabled {
     background-color: var(--gray-light);
     border: none;
+    color: var(--white);
     cursor: not-allowed;
   }
 }

--- a/src/components/video/index.scss
+++ b/src/components/video/index.scss
@@ -19,6 +19,15 @@
   z-index: 1;
 }
 
+.video-js .vjs-big-play-button {
+  border: none;
+  border-radius: 0;
+  line-height: 1.65em;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
 .vjs-text-track-display,
 .video-js .vjs-modal-dialog {
   height: 100%;
@@ -26,6 +35,7 @@
 }
 
 .vjs-control-bar {
+  background-color: var(--control-bar-color) !important;
   display: flex !important;
   position: fixed !important;
   z-index: 1 !important;

--- a/src/config.json
+++ b/src/config.json
@@ -4,9 +4,9 @@
     "scroll": true
   },
   "controls": {
-    "about": true,
+    "about": false,
     "fullscreen": true,
-    "search": true,
+    "search": false,
     "section": true,
     "swap": true,
     "thumbnails": true

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -16,22 +16,27 @@
 
   --green: rgb(0, 128, 129);
 
+  --white-dark: rgb(243, 246, 249);
   --white: rgb(255, 255, 255);
 
   --button-color: var(--blue);
   --button-box-shadow-color: rgba(15, 39, 33, .5);
 
+  --control-bar-color: var(--gray-dark);
+
   --cursor-color: var(--red);
 
   --marker-color: var(--red);
+
+  --title-color: var(--gray);
 
   --modal-background-color: rgba(6, 23, 42, .25);
 
   --thumbnails-background-color: var(--blue-lighter);
 
-  --body-background-color: var(--gray-dark);
+  --body-background-color: var(--white-dark);
   --section-background-color: var(--white);
-  --main-background-color: var(--gray-dark);
+  --main-background-color: var(--white-dark);
 
   --border-color: var(--gray-light);
 


### PR DESCRIPTION

![Screenshot_2020-08-06 Playback](https://user-images.githubusercontent.com/1778398/89593421-7665e400-d825-11ea-9c8f-fca9b2556b7a.png)
 

- Update background colour to background-color: rgb(243, 246, 249);
 - With updating the background colour to use the lighter grey,
   we’ll need to update the text and stand alone icon colours to
   use color: rgb(78, 90, 102);
 - Update slides button to use the full blue button colour;
 - Update the “-” icon to be a left chevron “<” to close the left
   panel and a right chevron “>” to open the left panel;
 - Center the “play button” to be in middle of the browser;
 - Hide the search button until the experience is more robust - we
   believe the current implementation may drive an increase in
   support tickets;
 - Move the swap button to the left hand side in replace of the
   search button.