### PR TITLE
Dynamic layout

### DIFF
--- a/src/components/bars/action.js
+++ b/src/components/bars/action.js
@@ -80,18 +80,23 @@ export default class ActionBar extends PureComponent {
       thumbnails,
     } = config;
 
-    const { presentation } = content;
+    const {
+      presentation,
+      screenshare,
+    } = content;
+
+    const single = !presentation && !screenshare;
 
     return (
       <div className="action-bar">
         <div className="left">
-          {control && swap ? this.renderSwapButton() : null}
+          {control && swap && !single ? this.renderSwapButton() : null}
         </div>
         <div className="center">
-          {control && search && presentation ? this.renderSearchButton() : null}
+          {control && search && !single ? this.renderSearchButton() : null}
         </div>
         <div className="right">
-          {control && thumbnails && presentation ? this.renderThumbnailsButton(): null}
+          {control && thumbnails && !single ? this.renderThumbnailsButton() : null}
         </div>
       </div>
     );

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -201,6 +201,7 @@ $error-font-size: 5rem;
       font-size: large;
       font-weight: var(--font-weight-semi-bold);
       outline: none;
+      overflow: hidden;
 
       [dir="ltr"] & {
         padding-left: $padding;

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -83,7 +83,7 @@ $error-font-size: 5rem;
 }
 
 .error-code {
-  color: var(--white);
+  color: var(--gray);
   font-size: $error-font-size;
   font-weight: var(--font-weight-bold);
 }

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -37,6 +37,15 @@ $error-font-size: 5rem;
   }
 }
 
+.single-content {
+  grid-template-areas:
+    "navigation-bar content"
+    "application content"
+    "application content"
+    "action-bar content";
+  grid-template-rows: $navigation-bar-height auto auto calc(#{$action-bar-height} / 2);
+}
+
 .hidden-section {
   grid-template-areas:
     "media navigation-bar"
@@ -253,6 +262,16 @@ $error-font-size: 5rem;
     }
   }
 
+  .single-content {
+    grid-template-areas:
+      "application navigation-bar"
+      "application content"
+      "application content"
+      "application content"
+      "application action-bar";
+    grid-template-rows: $navigation-bar-height $media-fit-height auto auto calc(#{$action-bar-height} / 2);
+  }
+
   .hidden-section {
     grid-template-columns: 0% auto;
   }
@@ -266,6 +285,10 @@ $error-font-size: 5rem;
     .player-wrapper {
       grid-template-columns: $section-width-small auto;
       grid-template-rows: $navigation-bar-height $media-fit-height-small auto auto $action-bar-height;
+    }
+
+    .single-content {
+      grid-template-rows: $navigation-bar-height $media-fit-height-small auto auto calc(#{$action-bar-height} / 2);
     }
 
     .hidden-section {

--- a/src/components/loader.js
+++ b/src/components/loader.js
@@ -80,7 +80,7 @@ class Loader extends PureComponent {
       }
     }).then(value => {
       build(file, value).then(data => {
-        logger.debug(ID.LOADER, 'builded', file);
+        if (data) logger.debug(ID.LOADER, 'builded', file);
         this.data[getFileName(file)] = data;
         this.update();
       }).catch(error => this.setState({ error: config.error['BAD_REQUEST'] }));

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -232,7 +232,14 @@ export default class Player extends PureComponent {
 
     if (!control || !controls.fullscreen) return null;
 
-    if (!isContentVisible(layout, swap)) return null;
+    const {
+      presentation,
+      screenshare,
+    } = this.content;
+
+    const single = !presentation && !screenshare;
+
+    if (!isContentVisible(layout, swap || single)) return null;
 
     const { intl } = this.props;
 
@@ -296,7 +303,14 @@ export default class Player extends PureComponent {
     const { intl } = this.props;
     const { swap } = this.state;
 
-    if (!isContentVisible(layout, swap)) return null;
+    const {
+      presentation,
+      screenshare,
+    } = this.content;
+
+    const single = !presentation && !screenshare;
+
+    if (!isContentVisible(layout, swap || single)) return null;
 
     return (
       <Talkers
@@ -356,7 +370,7 @@ export default class Player extends PureComponent {
     );
   }
 
-  renderMedia() {
+  renderMedia(single) {
     const {
       data,
       intl,
@@ -367,7 +381,7 @@ export default class Player extends PureComponent {
     const { media } = data;
 
     return (
-      <div className={cx('media', { 'swapped-media': swap })}>
+      <div className={cx('media', { 'swapped-media': swap || single })}>
         {this.renderTalkers(LAYOUT.MEDIA)}
         {this.renderFullscreenButton(LAYOUT.MEDIA)}
         <Video
@@ -490,7 +504,9 @@ export default class Player extends PureComponent {
     );
   }
 
-  renderContent() {
+  renderContent(single) {
+    if (single) return null;
+
     const {
       swap,
       time,
@@ -532,9 +548,17 @@ export default class Player extends PureComponent {
       section,
     } = this.state;
 
+    const {
+      presentation,
+      screenshare,
+    } = this.content;
+
+    const single = !presentation && !screenshare;
+
     const styles = {
       'fullscreen-content': fullscreen,
       'hidden-section': !section,
+      'single-content': single,
     };
 
     return (
@@ -544,9 +568,9 @@ export default class Player extends PureComponent {
         id={ID.PLAYER}
       >
         {this.renderNavigationBar()}
-        {this.renderMedia()}
+        {this.renderMedia(single)}
         {this.renderApplication()}
-        {this.renderContent()}
+        {this.renderContent(single)}
         {this.renderActionBar()}
         {this.renderThumbnails()}
         {this.renderModal()}

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -3,7 +3,6 @@ import cx from 'classnames';
 import { defineMessages } from 'react-intl';
 import {
   controls,
-  files,
   shortcuts,
 } from 'config';
 import About from './about';
@@ -26,8 +25,8 @@ import {
   getControlFromLayout,
   getCurrentDataIndex,
   getCurrentDataInterval,
+  getData,
   getDraws,
-  getFileName,
   getSectionFromLayout,
   getSwapFromLayout,
   hasPresentation,
@@ -82,16 +81,34 @@ export default class Player extends PureComponent {
       screenshare: null,
     };
 
-    this.alternates = data[getFileName(files.data.alternates)];
-    this.captions = data[getFileName(files.data.captions)];
-    this.chat = data[getFileName(files.data.chat)];
-    this.cursor = data[getFileName(files.data.cursor)];
-    this.metadata = data[getFileName(files.data.metadata)];
-    this.notes = data[getFileName(files.data.notes)];
-    this.panzooms = data[getFileName(files.data.panzooms)];
-    this.screenshare = data[getFileName(files.data.screenshare)];
-    this.shapes = data[getFileName(files.data.shapes)];
-    this.talkers = data[getFileName(files.data.talkers)];
+    this.initData(data);
+
+    this.handlePlayerReady = this.handlePlayerReady.bind(this);
+    this.handleTimeUpdate = this.handleTimeUpdate.bind(this);
+  }
+
+  componentDidMount() {
+    this.initMonitor();
+    this.initShortcuts();
+  }
+
+  componentWillUnmount() {
+    if (this.shortcuts) {
+      this.shortcuts.destroy();
+    }
+  }
+
+  initData(data) {
+    this.alternates = getData(data, ID.ALTERNATES);
+    this.captions = getData(data, ID.CAPTIONS);
+    this.chat = getData(data, ID.CHAT);
+    this.cursor = getData(data, ID.CURSOR);
+    this.metadata = getData(data, ID.METADATA);
+    this.notes = getData(data, ID.NOTES);
+    this.panzooms = getData(data, ID.PANZOOMS);
+    this.screenshare = getData(data, ID.SCREENSHARE);
+    this.shapes = getData(data, ID.SHAPES);
+    this.talkers = getData(data, ID.TALKERS);
 
     this.canvases = this.shapes.canvases;
     this.slides = this.shapes.slides;
@@ -105,21 +122,7 @@ export default class Player extends PureComponent {
       screenshare: !isEmpty(this.screenshare),
     };
 
-    this.handlePlayerReady = this.handlePlayerReady.bind(this);
-    this.handleTimeUpdate = this.handleTimeUpdate.bind(this);
-
     logger.debug(ID.PLAYER, data);
-  }
-
-  componentDidMount() {
-    this.initMonitor();
-    this.initShortcuts();
-  }
-
-  componentWillUnmount() {
-    if (this.shortcuts) {
-      this.shortcuts.destroy();
-    }
   }
 
   handlePlayerReady(media, player) {

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -470,8 +470,9 @@ const build = (filename, value) => {
       resolve(data);
     } else {
       if (!value) {
-        logger.error('missing', filename);
-        reject(filename);
+        logger.warn('missing', filename);
+
+        return resolve(null);
       }
 
       // Parse XML data

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -13,14 +13,20 @@ const LOCAL = process.env.REACT_APP_NO_ROUTER;
 
 const ID = {
   ABOUT: 'about',
+  ALTERNATES: 'alternates',
+  CAPTIONS: 'captions',
   CHAT: 'chat',
+  CURSOR: 'cursor',
   ERROR: 'error',
   LOADER: 'loader',
+  METADATA: 'metadata',
   NOTES: 'notes',
+  PANZOOMS: 'panzooms',
   PLAYER: 'player',
   PRESENTATION: 'presentation',
-  SEARCH: 'search',
   SCREENSHARE: 'screenshare',
+  SEARCH: 'search',
+  SHAPES: 'shapes',
   TALKERS: 'talkers',
   THUMBNAILS: 'thumbnails',
   VIDEO: 'video',
@@ -114,6 +120,44 @@ const getCurrentDataInterval = (data, time) => {
   }
 
   return currentDataInterval;
+};
+
+const getData = (data, id) => {
+  const file = config.files.data[id];
+
+  switch (id) {
+    case ID.ALTERNATES:
+    case ID.CAPTIONS:
+    case ID.CHAT:
+    case ID.CURSOR:
+    case ID.NOTES:
+    case ID.PANZOOMS:
+    case ID.SCREENSHARE:
+    case ID.TALKERS:
+      if (!file) return [];
+
+      return data[getFileName(file)];
+    case ID.METADATA:
+      if (!file) {
+        logger.error('missing', id);
+        return {};
+      }
+
+      return data[getFileName(file)];
+    case ID.SHAPES:
+      if (!file) {
+        return {
+          canvases: [],
+          slides: [],
+          thumbnails: [],
+        };
+      }
+
+      return data[getFileName(file)];
+    default:
+      logger.debug('unhandled', id);
+      return [];
+  }
 };
 
 const getDraws = (index, slides, canvases) => {
@@ -528,6 +572,7 @@ export {
   getControlFromLayout,
   getCurrentDataIndex,
   getCurrentDataInterval,
+  getData,
   getDraws,
   getFileName,
   getFileType,

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -134,18 +134,20 @@ const getData = (data, id) => {
     case ID.PANZOOMS:
     case ID.SCREENSHARE:
     case ID.TALKERS:
-      if (!file) return [];
+      if (!file || data[getFileName(file)] === null) {
+        return [];
+      }
 
       return data[getFileName(file)];
     case ID.METADATA:
-      if (!file) {
+      if (!file || data[getFileName(file)] === null) {
         logger.error('missing', id);
         return {};
       }
 
       return data[getFileName(file)];
     case ID.SHAPES:
-      if (!file) {
+      if (!file || data[getFileName(file)] === null) {
         return {
           canvases: [],
           slides: [],


### PR DESCRIPTION
This work is a starting point for building a more dynamic and automatic layout
for the recording's playback.

This first idea is to provide a better space usage for recordings that do
not provide presentation related data, such as slides, annotations, cursor
and panzooms nor screenshare (which occupies the same location at the playback).

![Peek 2020-08-08 09-09](https://user-images.githubusercontent.com/1778398/89714179-4d536980-d973-11ea-85bb-297d29997838.gif)

To use this option in custom builds and avoid the playback trying to fetch for
files that will never exist in a recording, the missing files can be removed
from files.data at config.json.

e.g. for a webcams with closed captions and chat case:
```
...
  "files": {
    "data": {
      "captions": "captions.json",
      "chat": "slides_new.xml",
      "metadata": "metadata.xml"
    },
...
```

Related with #15.