### PR TITLE
Inline thumbnail experience

### DIFF
--- a/src/components/bars/action.js
+++ b/src/components/bars/action.js
@@ -13,10 +13,6 @@ const intlMessages = defineMessages({
     id: 'button.swap.aria',
     description: 'Aria label for the swap button',
   },
-  thumbnails: {
-    id: 'button.thumbnails.aria',
-    description: 'Aria label for the thumbnails button',
-  },
 });
 
 export default class ActionBar extends PureComponent {
@@ -52,22 +48,6 @@ export default class ActionBar extends PureComponent {
     );
   }
 
-  renderThumbnailsButton() {
-    const {
-      intl,
-      toggleThumbnails,
-    } = this.props;
-
-    return (
-      <Button
-        aria={intl.formatMessage(intlMessages.thumbnails)}
-        handleOnClick={toggleThumbnails}
-        icon="rooms"
-        type="solid"
-      />
-    );
-  }
-
   render() {
     const {
       content,
@@ -77,7 +57,6 @@ export default class ActionBar extends PureComponent {
     const {
       search,
       swap,
-      thumbnails,
     } = config;
 
     const { presentation } = content;
@@ -90,9 +69,7 @@ export default class ActionBar extends PureComponent {
         <div className="center">
           {control && search && presentation ? this.renderSearchButton() : null}
         </div>
-        <div className="right">
-          {control && thumbnails && presentation ? this.renderThumbnailsButton(): null}
-        </div>
+        <div className="right" />
       </div>
     );
   }

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -120,10 +120,25 @@ $error-font-size: 5rem;
 .content {
   background-color: var(--main-background-color);
   display: flex;
+  flex-direction: column;
   grid-area: content;
   height: 100%;
-  position: relative;
   width: 100%;
+
+  .top-content {
+    display: flex;
+    height: 100%;
+    position: relative;
+    width: 100%;
+  }
+
+  .bottom-content {
+    background-color: var(--bottom-content-background-color);
+    display: flex;
+    min-height: $bottom-content-height;
+    position: relative;
+    width: 100%;
+  }
 
   .inactive {
     display: none;

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -73,7 +73,7 @@ export default class Player extends PureComponent {
       modal: '',
       section: getSectionFromLayout(layout),
       swap: getSwapFromLayout(layout),
-      thumbnails: false,
+      thumbnails: true,
       time: 0,
     }
 
@@ -304,14 +304,8 @@ export default class Player extends PureComponent {
   }
 
   renderThumbnails() {
-    const {
-      time,
-      thumbnails,
-    } = this.state;
-
-    if (!thumbnails) return null;
-
     const { intl } = this.props;
+    const { time } = this.state;
     const { video } = this.player;
 
     const currentDataIndex = getCurrentDataIndex(this.thumbnails, time);
@@ -489,18 +483,26 @@ export default class Player extends PureComponent {
 
   renderContent() {
     const {
+      fullscreen,
       swap,
+      thumbnails,
       time,
     } = this.state;
 
     const content = getActiveContent(this.screenshare, time);
+    const bottom = thumbnails && !fullscreen && !swap;
 
     return (
       <div className={cx('content', { 'swapped-content': swap })}>
         {this.renderTalkers(LAYOUT.CONTENT)}
         {this.renderFullscreenButton(LAYOUT.CONTENT)}
-        {this.renderPresentation(content === ID.PRESENTATION)}
-        {this.renderScreenshare(content === ID.SCREENSHARE)}
+        <div className="top-content">
+          {this.renderPresentation(content === ID.PRESENTATION)}
+          {this.renderScreenshare(content === ID.SCREENSHARE)}
+        </div>
+        <div className={cx('bottom-content', { inactive: !bottom })}>
+          {this.renderThumbnails()}
+        </div>
       </div>
     );
   }
@@ -516,7 +518,6 @@ export default class Player extends PureComponent {
         intl={intl}
         toggleSearch={() => this.toggleModal(ID.SEARCH)}
         toggleSwap={() => this.toggleSwap()}
-        toggleThumbnails={() => this.toggleThumbnails()}
       />
     );
   }
@@ -545,7 +546,6 @@ export default class Player extends PureComponent {
         {this.renderApplication()}
         {this.renderContent()}
         {this.renderActionBar()}
-        {this.renderThumbnails()}
         {this.renderModal()}
       </div>
     );

--- a/src/components/presentation/slide.js
+++ b/src/components/presentation/slide.js
@@ -3,6 +3,8 @@ import cx from 'classnames';
 import { buildFileURL } from 'utils/data';
 import './index.scss';
 
+const SCREENSHARE = 'deskshare';
+
 export default class Slide extends PureComponent {
   constructor(props) {
     super(props);
@@ -22,6 +24,8 @@ export default class Slide extends PureComponent {
       alt,
       src,
     } = thumbnail;
+
+    if (src === SCREENSHARE) return null;
 
     const logo = src.includes('logo');
 

--- a/src/components/thumbnails/index.js
+++ b/src/components/thumbnails/index.js
@@ -5,7 +5,7 @@ import { thumbnails as config } from 'config';
 import {
   ID,
   buildFileURL,
-  getScrollTop,
+  getScrollLeft,
 } from 'utils/data';
 import './index.scss';
 
@@ -60,7 +60,7 @@ export default class Thumbnails extends Component {
     if (this.firstNode && this.currentNode) {
       const { parentNode } = this.currentNode;
 
-      parentNode.scrollTop = getScrollTop(this.firstNode, this.currentNode, config.align);
+      parentNode.scrollLeft = getScrollLeft(this.firstNode, this.currentNode, config.align);
     }
   }
 
@@ -77,24 +77,17 @@ export default class Thumbnails extends Component {
     }
   }
 
-  renderThumbnail(item, active) {
+  renderImage(item) {
     const {
       alt,
       src,
-      timestamp,
     } = item;
 
     const screenshare = src === SCREENSHARE;
-    const onClick = () => this.handleOnClick(timestamp);
 
     if (screenshare) {
       return (
-        <div
-          className={cx('thumbnail', { active, screenshare })}
-          onClick={onClick}
-          onKeyPress={(e) => e.key === 'Enter' ? onClick() : null}
-          tabIndex="0"
-        >
+        <div className={cx('thumbnail-image', { screenshare })}>
           <span className="icon-desktop" />
         </div>
       );
@@ -103,11 +96,8 @@ export default class Thumbnails extends Component {
     return (
       <img
         alt={alt}
-        className={cx('thumbnail', { active })}
-        onClick={onClick}
-        onKeyPress={(e) => e.key === 'Enter' ? onClick() : null}
+        className="thumbnail-image"
         src={buildFileURL(this.recordId, src)}
-        tabIndex="0"
       />
     );
   }
@@ -120,13 +110,22 @@ export default class Thumbnails extends Component {
 
     return thumbnails.map((item, index) => {
       const active = index === currentDataIndex;
+      const onClick = () => this.handleOnClick(item.timestamp);
 
       return (
         <div
-          className="thumbnail-wrapper"
+          className={cx('thumbnail-wrapper', { active })}
+          onClick={onClick}
+          onKeyPress={(e) => e.key === 'Enter' ? onClick() : null}
           ref={node => this.setRef(node, index)}
+          tabIndex="0"
         >
-          {this.renderThumbnail(item, active)}
+          <div className="thumbnail">
+            {this.renderImage(item)}
+            <div className="thumbnail-index">
+              {index + 1}
+            </div>
+          </div>
         </div>
       );
     });

--- a/src/components/thumbnails/index.scss
+++ b/src/components/thumbnails/index.scss
@@ -1,58 +1,58 @@
 @import 'src/styles/icons';
 @import 'src/styles/sizes';
 
-$thumbnails-wrapper-top: $navigation-bar-height;
-$thumbnails-wrapper-bottom: calc(#{$control-bar-height} + #{$action-bar-height});
-$thumbnail-height: 90px;
+$thumbnail-height: calc((#{$bottom-content-height} / 10) * 6);
 
 .thumbnails-wrapper {
-  background-color: var(--thumbnails-background-color);
-  bottom: $thumbnails-wrapper-bottom;
-  box-sizing: border-box;
-  overflow-x: hidden;
-  overflow-y: auto;
-  padding: $padding-extra-small $padding-extra-small 0 $padding-extra-small;
-  position: fixed;
+  display: flex;
+  height: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  position: absolute;
   scroll-behavior: smooth;
-  top: $thumbnails-wrapper-top;
-  width: auto;
-  z-index: 1;
-
-  [dir="ltr"] & {
-    right: 0;
-  }
-
-  [dir="rtl"] & {
-    left: 0;
-  }
+  width: 100%;
 
   .active {
-    filter: opacity(50%);
+    background-color: var(--gray-lighter);
   }
 }
 
 .thumbnail-wrapper {
+  box-sizing: border-box;
+  cursor: pointer;
   display: flex;
-  height: $thumbnail-height;
-  justify-content: center;
-  padding: 0 0 $padding-extra-small 0;
+  padding: $padding-extra-small;
+  outline: none;
 
   .thumbnail {
-    cursor: pointer;
-    display: block;
-    height: 100%;
-    outline: none;
-    width: auto;
+    align-self: flex-start;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 
-    &:focus,
-    &:hover {
-      filter: opacity(50%);
+    .thumbnail-image {
+      display: block;
+      height: $thumbnail-height;
+      width: auto;
+    }
+
+    .thumbnail-index {
+      color: var(--gray);
+      display: flex;
+      font-size: x-small;
+      font-weight: var(--font-weight-bold);
+      margin-top: $margin-extra-small;
+    }
+
+    .screenshare {
+      color: var(--gray);
+      font-size: xx-large;
+      font-weight: var(--font-weight-semi-bold);
     }
   }
 
-  .screenshare {
-    color: var(--gray);
-    font-size: xx-large;
-    font-weight: var(--font-weight-semi-bold);
+  &:focus,
+  &:hover {
+    background-color: var(--gray-lighter);
   }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -73,7 +73,7 @@
     "valid": []
   },
   "thumbnails": {
-    "align": "bottom",
+    "align": "center",
     "scroll": true
   },
   "video": {

--- a/src/locales/messages/ar.json
+++ b/src/locales/messages/ar.json
@@ -6,7 +6,6 @@
   "button.search.aria": "بحث",
   "button.section.aria": "قسم جانبي",
   "button.swap.aria": "محتوى المبادلة",
-  "button.thumbnails.aria": "صور مصغرة",
   "error.wrapper.aria": "منطقة الخطأ",
   "loader.wrapper.aria": "منطقة اللودر",
   "player.wrapper.aria": "منطقة لاعب",

--- a/src/locales/messages/de.json
+++ b/src/locales/messages/de.json
@@ -6,7 +6,6 @@
   "button.search.aria": "Suche",
   "button.section.aria": "Seitenteil",
   "button.swap.aria": "Inhalte austauschen",
-  "button.thumbnails.aria": "Vorschaubilder",
   "error.wrapper.aria": "Fehlerbereich",
   "loader.wrapper.aria": "Laderbereich",
   "player.wrapper.aria": "Spielerbereich",

--- a/src/locales/messages/en.json
+++ b/src/locales/messages/en.json
@@ -6,7 +6,6 @@
   "button.search.aria": "Search",
   "button.section.aria": "Side section",
   "button.swap.aria": "Swap content",
-  "button.thumbnails.aria": "Thumbnails",
   "error.wrapper.aria": "Error area",
   "loader.wrapper.aria": "Loader area",
   "player.wrapper.aria": "Player area",

--- a/src/locales/messages/es.json
+++ b/src/locales/messages/es.json
@@ -6,7 +6,6 @@
   "button.search.aria": "Buscar",
   "button.section.aria": "Sección lateral",
   "button.swap.aria": "Intercambiar contenido",
-  "button.thumbnails.aria": "Miniaturas",
   "error.wrapper.aria": "Área de error",
   "loader.wrapper.aria": "Área del cargador",
   "player.wrapper.aria": "Área de reproductor",

--- a/src/locales/messages/fr.json
+++ b/src/locales/messages/fr.json
@@ -6,7 +6,6 @@
   "button.search.aria": "Chercher",
   "button.section.aria": "Section latérale",
   "button.swap.aria": "Contenu d'échange",
-  "button.thumbnails.aria": "Miniatures",
   "error.wrapper.aria": "Zone d'erreur",
   "loader.wrapper.aria": "Zone de chargement",
   "player.wrapper.aria": "Zone de lecteur",

--- a/src/locales/messages/it.json
+++ b/src/locales/messages/it.json
@@ -6,7 +6,6 @@
   "button.search.aria": "Ricerca",
   "button.section.aria": "Sezione laterale",
   "button.swap.aria": "Scambia contenuto",
-  "button.thumbnails.aria": "Miniature",
   "error.wrapper.aria": "Area di errore",
   "loader.wrapper.aria": "Area del caricatore",
   "player.wrapper.aria": "Area del lettore",

--- a/src/locales/messages/ja.json
+++ b/src/locales/messages/ja.json
@@ -6,7 +6,6 @@
   "button.search.aria": "探す",
   "button.section.aria": "サイドセクション",
   "button.swap.aria": "コンテンツを入れ替え",
-  "button.thumbnails.aria": "サムネイル",
   "error.wrapper.aria": "エラー領域",
   "loader.wrapper.aria": "ローダーエリア",
   "player.wrapper.aria": "プレイヤーエリア",

--- a/src/locales/messages/pt.json
+++ b/src/locales/messages/pt.json
@@ -6,7 +6,6 @@
   "button.search.aria": "Buscar",
   "button.section.aria": "Seção lateral",
   "button.swap.aria": "Trocar conteúdo",
-  "button.thumbnails.aria": "Miniaturas",
   "error.wrapper.aria": "Área do erro",
   "loader.wrapper.aria": "Área do carregador",
   "player.wrapper.aria": "Área do tocador",

--- a/src/locales/messages/ru.json
+++ b/src/locales/messages/ru.json
@@ -6,7 +6,6 @@
   "button.search.aria": "Поиск",
   "button.section.aria": "Боковой раздел",
   "button.swap.aria": "Обменяться контентом",
-  "button.thumbnails.aria": "Эскизы",
   "error.wrapper.aria": "Область ошибок",
   "loader.wrapper.aria": "Зона погрузчика",
   "player.wrapper.aria": "Игровая зона",

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -32,11 +32,11 @@
 
   --modal-background-color: rgba(6, 23, 42, .25);
 
-  --thumbnails-background-color: var(--blue-lighter);
-
   --body-background-color: var(--white-dark);
   --section-background-color: var(--white);
   --main-background-color: var(--white-dark);
+
+  --bottom-content-background-color: var(--gray-lightest);
 
   --border-color: var(--gray-light);
 

--- a/src/styles/sizes.scss
+++ b/src/styles/sizes.scss
@@ -10,6 +10,8 @@ $video-width: 640px;
 $section-width: calc(#{$video-width} / 2);
 $section-width-small: calc((#{$video-width} / 8) * 3);
 
+$bottom-content-height: 80px;
+
 $bar-height: 60px;
 
 $navigation-bar-height: $bar-height;

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -207,6 +207,38 @@ const getSwapFromLayout = layout => {
   return swap;
 };
 
+const getScrollLeft = (firstNode, currentNode, align) => {
+  if (!currentNode) return 0;
+
+  const {
+    clientWidth,
+    offsetLeft,
+    parentNode,
+  } = currentNode;
+
+  if (!firstNode || !parentNode) return 0;
+
+  const spacing = firstNode.offsetLeft;
+  const parentWidth = parentNode.clientWidth;
+
+  let horizontalOffset = 0;
+  switch (align) {
+    case 'left':
+      horizontalOffset = offsetLeft - spacing;
+      break;
+    case 'center':
+      horizontalOffset = parseInt(offsetLeft + (clientWidth - spacing - parentWidth) / 2, 10);
+      break;
+    case 'right':
+      horizontalOffset = offsetLeft + clientWidth - parentWidth;
+      break;
+    default:
+      logger.debug('unhandled', align);
+  }
+
+  return horizontalOffset;
+};
+
 const getScrollTop = (firstNode, currentNode, align) => {
   if (!currentNode) return 0;
 
@@ -226,7 +258,7 @@ const getScrollTop = (firstNode, currentNode, align) => {
     case 'top':
       verticalOffset = offsetTop - spacing;
       break;
-    case 'center':
+    case 'middle':
       verticalOffset = parseInt(offsetTop + (clientHeight - spacing - parentHeight) / 2, 10);
       break;
     case 'bottom':
@@ -533,6 +565,7 @@ export {
   getFileType,
   getLayout,
   getRecordId,
+  getScrollLeft,
   getScrollTop,
   getSectionFromLayout,
   getSwapFromLayout,


### PR DESCRIPTION
Replaces the toggle button for a content bottom inline thumbnails' view.

![Peek 2020-08-09 17-31](https://user-images.githubusercontent.com/1778398/89741672-84a44200-da69-11ea-8e38-01b9b8672832.gif)

This change also includes an automated horizontal scroll and still maintain
the thumbnails' keyboard shortcut.

Closes #63 .