### PR TITLE
Add logo thumbnail

### DIFF
--- a/src/components/thumbnails/index.js
+++ b/src/components/thumbnails/index.js
@@ -120,10 +120,12 @@ export default class Thumbnails extends Component {
       );
     }
 
+    const logo = src.includes('logo');
+
     return (
       <img
         alt={alt}
-        className="thumbnail-image"
+        className={cx('thumbnail-image', { logo })}
         src={buildFileURL(this.recordId, src)}
       />
     );

--- a/src/components/thumbnails/index.scss
+++ b/src/components/thumbnails/index.scss
@@ -1,4 +1,5 @@
 @import 'src/styles/icons';
+@import 'src/styles/images';
 @import 'src/styles/sizes';
 
 $thumbnail-height: calc((#{$bottom-content-height} / 10) * 6);

--- a/src/styles/images.scss
+++ b/src/styles/images.scss
@@ -3,3 +3,9 @@
   background-position: center center;
   background-repeat: no-repeat;
 }
+
+.thumbnail {
+  .logo {
+    background-size: contain;
+  }
+}


### PR DESCRIPTION
This includes the missing logo background image to the thumbnails. Usually
the logo slide occurs when the meeting is defined as autoStartRecordng.

Closes #73 .