### PR TITLE
Hide chat data overflow

### DIFF
--- a/src/components/chat/index.scss
+++ b/src/components/chat/index.scss
@@ -46,6 +46,7 @@
   .data {
     display: flex;
     flex-direction: column;
+    overflow: hidden;
     width:100%;
 
     [dir="ltr"] & {


### PR DESCRIPTION
When an user had a long name all the data inside the chat message was being
pushed out of the application's container. This change set the style to avoid
overflowing this component data.

Closes #82 .