### PR TITLE
Allow loading media from a different path or an external URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ PUBLIC_URL=. REACT_APP_NO_ROUTER=1 npm run-script build
 ```
 And then copy all of the files from the bbb-playback `build` directory and the files from `/var/bigbluebutton/published/presentation/<recordid>` together into a single directory.
 
+## External recordings
+
+bbb-playback can play recordings hosted somewhere other than the default location. To do this, build the bbb-playback with the following options:
+```
+REACT_APP_MEDIA_ROOT_URL=/different/relative/path/to/presentation/files npm run-script build
+```
+You can also play medias from an external server. Note that you will need to have the `Access-Control-Allow-Origin` header returned on the medias for that to work.
+```
+REACT_APP_MEDIA_ROOT_URL=https://my-media-server.example.com npm run-script build
+```
+
 ## Playing old recordings
 
 At `/etc/bigbluebutton/nginx/presentation.nginx`:

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -46,10 +46,12 @@ const getRouter = () => {
 
 const ROUTER = getRouter();
 
+const MEDIA_ROOT_URL = process.env.REACT_APP_MEDIA_ROOT_URL;
+
 const buildFileURL = (recordId, file) => {
   if (!ROUTER) return file;
 
-  return `/presentation/${recordId}/${file}`;
+  return `${MEDIA_ROOT_URL ? MEDIA_ROOT_URL : '/presentation'}/${recordId}/${file}`;
 };
 
 const getAvatarStyle = name => {


### PR DESCRIPTION
Hey!

We intent to deploy `bbb-playback` on a separate server from where the medias will be stored. We needed an option to load medias from somewhere else than the default location. We though this feature could be useful for others too.

Let me know what you think!