### PR TITLE
Fix TypeError: Cannot read property 'formatMessage' of undefined

### DIFF
--- a/src/components/error.js
+++ b/src/components/error.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, useIntl } from 'react-intl';
 import { ID } from 'utils/data';
 import './index.scss';
 
@@ -11,9 +11,9 @@ const intlMessages = defineMessages({
 });
 
 export default function Error(props) {
+  const intl = useIntl();
   const {
     code,
-    intl,
   } = props;
 
   return (

--- a/src/components/loader.js
+++ b/src/components/loader.js
@@ -138,7 +138,6 @@ class Loader extends PureComponent {
       return (
         <Error
           code={error}
-          intl={intl}
         />
       );
     }


### PR DESCRIPTION
Fixes an error where the router was not able to render the generic error page because `intl` was missing. This happens on routing errors for example when the `meetingId` is completely missing.

Before:
![localhost_3000_playback_presentation_2 3 (1)](https://user-images.githubusercontent.com/923718/110165006-34ebe600-7dc0-11eb-8bfd-a8f080cbcb64.png)

After:
![localhost_3000_playback_presentation_2 3](https://user-images.githubusercontent.com/923718/110164983-2a315100-7dc0-11eb-987d-8f7d555b5e01.png)

Note that I'm not well versed in the subtleties of React. There may be a better fix. 
