### PR TITLE
Avoid auto scroll while user interaction

### DIFF
--- a/src/components/chat/index.js
+++ b/src/components/chat/index.js
@@ -16,6 +16,12 @@ const intlMessages = defineMessages({
 });
 
 export default class Chat extends Component {
+  constructor(props) {
+    super(props);
+
+    this.interaction = false;
+  }
+
   componentDidMount() {
     this.handleAutoScroll();
   }
@@ -35,7 +41,7 @@ export default class Chat extends Component {
   }
 
   handleAutoScroll() {
-    if (!config.scroll) return;
+    if (!config.scroll || this.interaction) return;
 
     // Auto-scroll can start after getting the first and current nodes
     if (this.firstNode && this.currentNode) {
@@ -111,7 +117,11 @@ export default class Chat extends Component {
         tabIndex="0"
       >
         <div className="list">
-          <div className="message-wrapper">
+          <div
+            className="message-wrapper"
+            onMouseEnter={() => this.interaction = true}
+            onMouseLeave={() => this.interaction = false}
+          >
             {this.renderMessages()}
           </div>
         </div>

--- a/src/components/thumbnails/index.js
+++ b/src/components/thumbnails/index.js
@@ -32,6 +32,7 @@ export default class Thumbnails extends Component {
     const { metadata } = props;
 
     this.recordId = metadata.id;
+    this.interaction = false;
   }
 
   componentDidMount() {
@@ -68,7 +69,7 @@ export default class Thumbnails extends Component {
   }
 
   handleAutoScroll() {
-    if (!config.scroll) return;
+    if (!config.scroll || this.interaction) return;
 
     // Auto-scroll can start after getting the first and current nodes
     if (this.firstNode && this.currentNode) {
@@ -223,6 +224,8 @@ export default class Thumbnails extends Component {
         aria-label={intl.formatMessage(intlMessages.aria)}
         className="thumbnails-wrapper"
         id={ID.THUMBNAILS}
+        onMouseEnter={() => this.interaction = true}
+        onMouseLeave={() => this.interaction = false}
         tabIndex="0"
       >
         {this.renderThumbnails()}


### PR DESCRIPTION
This change prevents auto scroll to force a position update while the
user has her/his mouse over the scrollable element.

Reported by @LLCarlos & @fcecagno