### PR TITLE
Add mediaPath parameter in order to be able to specify assets folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ https://<domain>/playback/presentation/2.3/<recordId>
   - `t=MmSs`
   - `t=Ss`
 
+- path:
+  - `p=path/to/recordings`
+
 - log:
   - `debug`
 

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -51,7 +51,16 @@ const MEDIA_ROOT_URL = process.env.REACT_APP_MEDIA_ROOT_URL;
 const buildFileURL = (recordId, file) => {
   if (!ROUTER) return file;
 
-  return `${MEDIA_ROOT_URL ? MEDIA_ROOT_URL : '/presentation'}/${recordId}/${file}`;
+  const mediaPath = getMediaPath();
+
+  const rootUrl = MEDIA_ROOT_URL ? MEDIA_ROOT_URL : '/presentation';
+  let fileUrl = `${recordId}/${file}`;
+
+  if(mediaPath) {
+    fileUrl = `${mediaPath}/${fileUrl}`;
+  }
+
+  return `${rootUrl}/${fileUrl}`;
 };
 
 const getAvatarStyle = name => {
@@ -363,6 +372,17 @@ const getStyle = () => {
   return style;
 };
 
+const getMediaPath = () => {
+  const params = new URLSearchParams(window.location.search);
+  let mediaPath = "";
+
+  if (params && params.has('p')) {
+    mediaPath = params.get('p');
+  }
+
+  return mediaPath;
+};
+
 const getTime = location => {
   if (location) {
     const { search } = location;
@@ -650,6 +670,7 @@ export {
   getFileName,
   getFileType,
   getLayout,
+  getMediaPath,
   getRecordId,
   getScrollLeft,
   getScrollTop,


### PR DESCRIPTION
Hi!

I'm not sure this is an appropriate pull request, but since we needed to do it for us I figured it was probably worth a discussion anyway. This may not be a very popular use case, but we needed more flexibility regarding the assets path to the files of a recording.

We use the functionality documented in the README to specify external path for records. However, there are several places in the code that the player builds a file path using the informations stored within medadata.

In our case, the user accesses the player via

http://example.org/playback/presentation/2.3/{meetingId}

However, the recordings in our app are splitted into different folders depending on the tenant to avoid listing all the recordings within the same folder. When the player rebuilds the file urls strictly according to the `meeting_id`, it does not have enough context to determine the nested location of the resource.

This is where `mediaPath` comes into play.

I decided to add an optional parameter at the end of the route that is used to send the path to the media folder that contains the files for the recording.

`/playback/presentation/2.3/<recordId>/<mediaPath>`

This way, we are able to specify the path containing the media files.

I have to admit that I am not very familiar with react, so I would be more than happy to be pointed out in the right direction if this solution is completely far fetched.

I'd be more happy to add more explanation within the README if there is any interest in such a feature within the core of the player.