### PR TITLE
fix(synchronizer): media sync on visible

### DIFF
--- a/src/utils/synchronizer.js
+++ b/src/utils/synchronizer.js
@@ -97,6 +97,16 @@ export default class Synchronizer {
       }
     });
 
+    // IMPORTANT: Blink holds the secondary media down while the document
+    // page is not visible
+    // Force medias to sync on visibility change and document is visible
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        const currentTime = this.primary.currentTime();
+        this.secondary.currentTime(currentTime);
+      }
+    });
+
     EVENTS.forEach(event => {
       this.primary.on(event, () => logger.debug(`primary ${event} ${this.status.primary}`));
       this.secondary.on(event, () => logger.debug(`secondary ${event} ${this.status.secondary}`));


### PR DESCRIPTION
Blink based browsers pause the secondary media (screenshare) while the
document is not visible.

Add a seek-sync routine to be dispatched when the document's visibilityState
changes to visible.

Closes #74