### PR TITLE
Avoid nginx reload error when deploying

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -13,7 +13,7 @@ sudo cp -r ./build $BBB_PLAYBACK
 sudo chown --recursive bigbluebutton:bigbluebutton $BBB_PLAYBACK
 
 BBB_NGINX_FILES_PATH=/etc/bigbluebutton/nginx
-if [ ! -f $BBB_NGINX_FILES_PATH/playback.nginx ]; then
+if [ ! -f $BBB_NGINX_FILES_PATH/playback.nginx ] && [ ! -f $BBB_NGINX_FILES_PATH/bbb-playback.nginx ]; then
   sudo cp ./playback.nginx $BBB_NGINX_FILES_PATH
   sudo systemctl reload nginx
 fi


### PR DESCRIPTION
Recently I realised that the file bbb-playback.nginx is present at /etc/bigbluebutton/nginx/. This has probably come from BBB install script. 

The problem is  bbb-playback.nginx and playback.nginx is duplicated, so "sudo systemctl reload nginx" in deploy.sh fails with "location /playback/presentation/2.3 is duplicated" error. 

This patch prevents deploy.sh from copying playback.nginx when bbb-playback.nginx is already present.