### PR TITLE
feat(media): fallback audio support

### DIFF
--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -24,6 +24,15 @@ const intlMessages = defineMessages({
 });
 
 const buildSources = () => {
+  if (storage.fallback) {
+    return [
+      {
+        src: buildFileURL('audio/audio.webm'),
+        type: 'audio/webm',
+      },
+    ];
+  }
+
   return [
     {
       src: buildFileURL('video/webcams.mp4'),


### PR DESCRIPTION
EXPERIMENTAL: pre-v2.2 BigBlueButton could generate audio-only
recordings. This changes add support for webm containers for such
recordings.

TODO: add support for mp3 audio-only recordings.

Closes #112