### PR TITLE
fix(canvases): empty canvas force clean

### DIFF
--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -255,7 +255,6 @@ const buildCanvases = (group, slides) => {
     canvases = group.map(canvas => {
       const canvasAttr = getAttr(canvas);
       const canvasId = getId(canvasAttr.id);
-      const { timestamp } = slides.find(slide => slide.id === canvasId);
 
       let data = canvas.g.map(g => {
         const drawAttr = getAttr(g);
@@ -310,10 +309,24 @@ const buildCanvases = (group, slides) => {
       return {
         data,
         id: canvasId,
-        timestamp,
       };
     });
   }
+
+  slides.forEach((slide, index) => {
+    const found = canvases.find(canvas => canvas.id === slide.id);
+    if (found) {
+      canvases[index].timestamp = slide.timestamp;
+    } else {
+      const canvas = {
+        data: [],
+        id: slide.id,
+        timestamp: slide.timestamp,
+      };
+
+      canvases.splice(index, 0, canvas);
+    }
+  });
 
   return canvases;
 };


### PR DESCRIPTION
Add empty canvases to listen for all slide changes and avoid carrying
the previous slide annotations to the following one.