### PR TITLE
feat(params): render frequency control

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ https://<domain>/playback/presentation/2.3/<recordId>
 
 ## URL query strings
 
+- frequency:
+  - `f=<value>`: renders per second (e.g., 5)
+
 - layout:
   - `l=content`: focus on content
   - `l=disabled`: disabled interactive elements

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -11,7 +11,10 @@ import {
 } from 'utils/constants';
 import { buildFileURL } from 'utils/data';
 import logger from 'utils/logger';
-import { getTime } from 'utils/params';
+import {
+  getFrequency,
+  getTime,
+} from 'utils/params';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
 import './index.scss';
@@ -98,10 +101,11 @@ const Webcams = () => {
 
       player.webcams = videojs(video, buildOptions(sources, tracks), () => {
         player.webcams.on('play', () => {
+          const frequency = getFrequency();
           interval.current = setInterval(() => {
             const currentTime = player.webcams.currentTime();
             dispatchTimeUpdate(currentTime);
-          }, 1000 / config.rps);
+          }, 1000 / (frequency ? frequency : config.rps));
         });
 
         player.webcams.on('pause', () => clearInterval(interval.current));

--- a/src/utils/params.js
+++ b/src/utils/params.js
@@ -2,6 +2,14 @@ import config from 'config';
 import { ROUTER } from './constants';
 import logger from './logger';
 
+const getFrequency = () => {
+  const param = getSearchParam('f');
+
+  if (param) return parseFloat(param);
+
+  return null;
+};
+
 const getLayout = () => {
   const param = getSearchParam('l');
 
@@ -119,6 +127,7 @@ const parseTimeToSeconds = time => {
 };
 
 export {
+  getFrequency,
   getLayout,
   getMediaPath,
   getRecordId,


### PR DESCRIPTION
Add new `f` query string param to control the player renders' frequency
per run. This is useful for profiling performance without rebuilding the
app.