### PR TITLE
feat(config): disable the recording date

### DIFF
--- a/src/components/bars/top/title.js
+++ b/src/components/bars/top/title.js
@@ -6,7 +6,10 @@ import {
   FormattedDate,
 } from 'react-intl';
 import cx from 'classnames';
-import { controls as config } from 'config';
+import {
+  controls as config,
+  date,
+} from 'config';
 import { handleOnEnterPress } from 'utils/data/handlers';
 import storage from 'utils/data/storage';
 import layout from 'utils/layout';
@@ -25,14 +28,17 @@ const defaultProps = { openAbout: () => {} };
 
 const Title = ({ openAbout }) => {
   const intl = useIntl();
-  const date = <FormattedDate value={new Date(storage.metadata.start)} />;
+  const start = <FormattedDate value={new Date(storage.metadata.start)} />;
 
   const interactive = layout.control && config.about;
   if (!interactive) {
 
     return (
       <span className="title">
-        {storage.metadata.name} - {date}
+        {storage.metadata.name}
+        {date.enabled ? (
+          <> - {start}</>
+        ) : null}
       </span>
     );
   }
@@ -45,7 +51,10 @@ const Title = ({ openAbout }) => {
       onKeyPress={event => handleOnEnterPress(event, openAbout)}
       tabIndex="0"
     >
-      {storage.metadata.name} - {date}
+      {storage.metadata.name}
+      {date.enabled ? (
+        <> - {start}</>
+      ) : null}
     </span>
   );
 };

--- a/src/components/modals/about/header.js
+++ b/src/components/modals/about/header.js
@@ -3,6 +3,7 @@ import {
   FormattedDate,
   FormattedTime,
 } from 'react-intl';
+import { date } from 'config';
 import storage from 'utils/data/storage';
 import './index.scss';
 
@@ -14,17 +15,19 @@ const Header = () => {
   } = storage.metadata;
 
   const subtitle = [];
-  subtitle.push(
-    <FormattedDate
-      value={new Date(start)}
-      day="numeric"
-      month="long"
-      year="numeric"
-    />
-  );
+  if (date.enabled) {
+    subtitle.push(
+      <FormattedDate
+        value={new Date(start)}
+        day="numeric"
+        month="long"
+        year="numeric"
+      />
+    );
 
-  subtitle.push(<FormattedTime value={new Date(start)} />);
-  subtitle.push(<FormattedTime value={new Date(end)} />);
+    subtitle.push(<FormattedTime value={new Date(start)} />);
+    subtitle.push(<FormattedTime value={new Date(end)} />);
+  }
 
   return (
     <div className="about-header">

--- a/src/config.json
+++ b/src/config.json
@@ -11,6 +11,9 @@
     "swap": true,
     "thumbnails": true
   },
+  "date": {
+    "enabled": true
+  },
   "files": {
     "alternates": "presentation_text.json",
     "captions": "captions.json",


### PR DESCRIPTION
Add option to hide the recording date from the playback UI.

IMPORTANT: this does not remove user's complete access to the date the
recording was made. BigBlueButton uses the epoch timestamp as part
of the `recordingId`. Anyone a little more curious can still get that number
and convert it to a human readable date.

Closes #151