### PR TITLE
fix(player): update data on media seeked

### DIFF
--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -110,6 +110,11 @@ const Webcams = () => {
 
         player.webcams.on('pause', () => clearInterval(interval.current));
 
+        player.webcams.on('seeked', () => {
+          const currentTime = player.webcams.currentTime();
+          dispatchTimeUpdate(currentTime);
+        });
+
         const time = getTime();
         if (time) {
           player.webcams.on('loadedmetadata', () => {


### PR DESCRIPTION
Add a `seeked` event listener at the primary media to force update the
player's data when the media is paused.

Closes #160