### PR TITLE
feat(chat): moderators' messages

### DIFF
--- a/src/components/chat/messages/index.js
+++ b/src/components/chat/messages/index.js
@@ -39,6 +39,7 @@ const Messages = ({
                     active={active}
                     hyperlink={item.hyperlink}
                     initials={item.initials}
+                    moderator={item.moderator}
                     name={item.name}
                     text={item.message}
                     timestamp={timestamp}

--- a/src/components/chat/messages/user/index.js
+++ b/src/components/chat/messages/user/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { chat as config } from 'config';
 import Text from './text';
 import Message from 'components/chat/messages/message';
 
@@ -7,6 +8,7 @@ const propTypes = {
   active: PropTypes.bool,
   hyperlink: PropTypes.bool,
   initials: PropTypes.string,
+  moderator: PropTypes.bool,
   name: PropTypes.string,
   text: PropTypes.string,
   timestamp: PropTypes.timestamp,
@@ -16,6 +18,7 @@ const defaultProps = {
   active: false,
   hyperlink: false,
   initials: '',
+  moderator: false,
   name: '',
   text: '',
   timestamp: 0,
@@ -25,6 +28,7 @@ const User = ({
   active,
   hyperlink,
   initials,
+  moderator,
   name,
   text,
   timestamp,
@@ -33,13 +37,14 @@ const User = ({
   return (
     <Message
       active={active}
-      circle
+      circle={!moderator}
       initials={initials}
       name={name}
       timestamp={timestamp}
     >
       <Text
         active={active}
+        emphasize={config.emphasize && moderator}
         hyperlink={hyperlink}
         text={text}
       />

--- a/src/components/chat/messages/user/index.scss
+++ b/src/components/chat/messages/user/index.scss
@@ -1,0 +1,3 @@
+.emphasize {
+  font-weight: var(--font-weight-semi-bold);
+}

--- a/src/components/chat/messages/user/text.js
+++ b/src/components/chat/messages/user/text.js
@@ -2,27 +2,31 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Linkify from 'linkifyjs/react';
 import cx from 'classnames';
+import './index.scss';
 
 const propTypes = {
   active: PropTypes.bool,
+  emphasize: PropTypes.bool,
   hyperlink: PropTypes.bool,
   text: PropTypes.string,
 };
 
 const defaultProps = {
   active: false,
+  emphasize: false,
   hyperlink: false,
   text: '',
 };
 
 const Text = ({
   active,
+  emphasize,
   hyperlink,
   text,
 }) => {
   if (hyperlink) {
     const options = {
-      className: cx('linkified', { inactive: !active }),
+      className: cx('linkified', { inactive: !active, emphasize }),
     };
 
     return (
@@ -33,9 +37,9 @@ const Text = ({
   }
 
   return (
-    <React.Fragment>
+    <div className={cx({ emphasize })}>
       {text}
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/src/components/utils/avatar/index.js
+++ b/src/components/utils/avatar/index.js
@@ -25,7 +25,7 @@ const Avatar = ({
   initials,
   name,
 }) => {
-  const style = circle ? getAvatarStyle(name) : 'avatar-default';
+  const style = initials.length > 0 ? getAvatarStyle(name) : 'avatar-default';
 
   return (
     <div className="avatar-wrapper">

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,7 @@
 {
   "chat": {
     "align": "bottom",
+    "emphasize": true,
     "scroll": true
   },
   "controls": {

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -430,6 +430,7 @@ const buildChat = result => {
       const clear = attr.out ? parseFloat(attr.out) : -1;
       const message = decodeXML(clearHyperlink(attr.message));
       const initials = getInitials(attr.name);
+      const moderator = attr.moderator ? true : false;
 
       return {
         clear,
@@ -437,6 +438,7 @@ const buildChat = result => {
         initials,
         name: attr.name,
         message,
+        moderator,
         timestamp: parseFloat(attr.in),
       };
     });


### PR DESCRIPTION
Add the squared avatar for moderators and a configuration option to
emphasize the moderator's chat message with a bold font weight.

Moderator's text emphasized by default.

Part of https://github.com/bigbluebutton/bigbluebutton/pull/14227