### PR TITLE
Fix mispositioned caption popup

### DIFF
--- a/src/components/player/buttons/index.scss
+++ b/src/components/player/buttons/index.scss
@@ -39,3 +39,10 @@
     }
   }
 }
+
+.vjs-menu-button-popup {
+  .vjs-menu {
+    left: unset!important;
+    right: 0em!important;
+  }
+}


### PR DESCRIPTION
This patch fixes the problem reported in #166 and #103.
As far as I understand, it's a problem from video.js, not from bbb-playback. 
This PR may offer a decent workaround until the problem is fixed in the video.js side.

![2 0](https://user-images.githubusercontent.com/45039819/157439858-2436e283-22b1-4236-8f1d-a1b613a4985c.jpeg)
.