### PR TITLE
fix(canvas): preserve annotation colors

### DIFF
--- a/src/components/bars/top/buttons/theme.js
+++ b/src/components/bars/top/buttons/theme.js
@@ -28,7 +28,19 @@ const css = `
 }
 `;
 
-const fixes = { css };
+const ignoreInlineStyle = [
+  'g > circle',
+  'g > line',
+  'g > path',
+  'g > polygon',
+  'g > polyline',
+  'g > foreignObject',
+];
+
+const fixes = {
+  css,
+  ignoreInlineStyle,
+};
 
 const Theme = () => {
   const intl = useIntl();


### PR DESCRIPTION
Avoid replacing the annotation colors when the dark mode is enabled.

Closes #192 