### PR TITLE
fix(tldraw): respect view area width/height +

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@tldraw/tldraw": "^1.16.0",
+        "@tldraw/tldraw": "^1.20.0",
         "classnames": "^2.3.1",
         "darkreader": "^4.9.46",
         "linkify-react": "^3.0.4",
@@ -3711,12 +3711,12 @@
       }
     },
     "node_modules/@tldraw/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-vXsg6AqoOj3ruaN6+BASla+VX/doaU9mu0R0Px3jzVwZzVPsWwgLaUvl8K0sQ4HzGNip6RX6uOH/TlD1ZLsBuw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-4A9Xyh/VQBCtzVxZF/a7pXkP6AbFqVE8LcD9gmKWnaSYW6haLhc/Ie1O477T5xKV2HMfWJ52x1dUEn3jOGFVCg==",
       "dependencies": {
         "@tldraw/intersect": "^1.7.1",
-        "@tldraw/vec": "^1.7.0",
+        "@tldraw/vec": "^1.7.1",
         "@use-gesture/react": "^10.2.14",
         "mobx-react-lite": "^3.2.3",
         "perfect-freehand": "^1.1.0",
@@ -3736,19 +3736,21 @@
       }
     },
     "node_modules/@tldraw/tldraw": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.17.1.tgz",
-      "integrity": "sha512-FUuUpGwuEVRdPJW4pPyRvnKI9l6OKc+sVnzjQFAMppoti9sUnnjgxCE3oQ+GQSjVBKHhCfe+2t7+MaZW9OVN6w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.20.0.tgz",
+      "integrity": "sha512-dVy/l7ceTRwEBzpFvmT2vqDCmbiAJtF55Jv6At9Y9oNDF+xT81dgXupHVw0wSiQRW3ZwD2hxPjnFWqi6uHBS+w==",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^0.1.7",
         "@radix-ui/react-context-menu": "^0.1.6",
+        "@radix-ui/react-dialog": "^0.1.7",
         "@radix-ui/react-dropdown-menu": "^0.1.6",
         "@radix-ui/react-icons": "^1.1.1",
+        "@radix-ui/react-popover": "^0.1.6",
         "@radix-ui/react-tooltip": "^0.1.7",
         "@stitches/react": "^1.2.8",
-        "@tldraw/core": "^1.14.0",
+        "@tldraw/core": "^1.15.0",
         "@tldraw/intersect": "^1.7.1",
-        "@tldraw/vec": "^1.7.0",
+        "@tldraw/vec": "^1.7.1",
         "idb-keyval": "^6.1.0",
         "lz-string": "^1.4.4",
         "perfect-freehand": "^1.1.0",
@@ -3796,202 +3798,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
       "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-0.1.7.tgz",
-      "integrity": "sha512-jXt8srGhHBRvEr9jhEAiwwJzWCWZoGRJ030aC9ja/gkRJbZdy0iD3FwXf+Ff4RtsZyLUMHW7VUwFOlz3Ixe1Vw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "0.1.0",
-        "@radix-ui/react-compose-refs": "0.1.0",
-        "@radix-ui/react-context": "0.1.1",
-        "@radix-ui/react-dismissable-layer": "0.1.5",
-        "@radix-ui/react-focus-guards": "0.1.0",
-        "@radix-ui/react-focus-scope": "0.1.4",
-        "@radix-ui/react-id": "0.1.5",
-        "@radix-ui/react-portal": "0.1.4",
-        "@radix-ui/react-presence": "0.1.2",
-        "@radix-ui/react-primitive": "0.1.4",
-        "@radix-ui/react-slot": "0.1.2",
-        "@radix-ui/react-use-controllable-state": "0.1.0",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "^2.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0",
-        "react-dom": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.5.tgz",
-      "integrity": "sha512-J+fYWijkX4M4QKwf9dtu1oC0U6e6CEl8WhBp3Ad23yz2Hia0XCo6Pk/mp5CAFy4QBtQedTSkhW05AdtSOEoajQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "0.1.0",
-        "@radix-ui/react-compose-refs": "0.1.0",
-        "@radix-ui/react-primitive": "0.1.4",
-        "@radix-ui/react-use-body-pointer-events": "0.1.1",
-        "@radix-ui/react-use-callback-ref": "0.1.0",
-        "@radix-ui/react-use-escape-keydown": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-body-pointer-events": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.1.tgz",
-      "integrity": "sha512-R8leV2AWmJokTmERM8cMXFHWSiv/fzOLhG/JLmRBhLTAzOj37EQizssq4oW0Z29VcZy2tODMi9Pk/htxwb+xpA==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-body-pointer-events/node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
-      "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
-      "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.4.tgz",
-      "integrity": "sha512-fbA4ES3H4Wkxp+OeLhvN6SwL7mXNn/aBtUf7DRYxY9+Akrf7dRxl2ck4lgcpPsSg3zSDsEwLcY+h5cmj5yvlug==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0",
-        "@radix-ui/react-primitive": "0.1.4",
-        "@radix-ui/react-use-callback-ref": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
-      "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.4.tgz",
-      "integrity": "sha512-MO0wRy2eYRTZ/CyOri9NANCAtAtq89DEtg90gicaTlkCfdqCLEBsLb+/q66BZQTr3xX/Vq01nnVfc/TkCqoqvw==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-primitive": "0.1.4",
-        "@radix-ui/react-use-layout-effect": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0",
-        "react-dom": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
-      "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
@@ -4385,6 +4191,248 @@
         "react": "^16.8 || ^17.0"
       }
     },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-0.1.7.tgz",
+      "integrity": "sha512-jXt8srGhHBRvEr9jhEAiwwJzWCWZoGRJ030aC9ja/gkRJbZdy0iD3FwXf+Ff4RtsZyLUMHW7VUwFOlz3Ixe1Vw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-dismissable-layer": "0.1.5",
+        "@radix-ui/react-focus-guards": "0.1.0",
+        "@radix-ui/react-focus-scope": "0.1.4",
+        "@radix-ui/react-id": "0.1.5",
+        "@radix-ui/react-portal": "0.1.4",
+        "@radix-ui/react-presence": "0.1.2",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-slot": "0.1.2",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0",
+        "react-dom": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+      "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+      "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.5.tgz",
+      "integrity": "sha512-J+fYWijkX4M4QKwf9dtu1oC0U6e6CEl8WhBp3Ad23yz2Hia0XCo6Pk/mp5CAFy4QBtQedTSkhW05AdtSOEoajQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-body-pointer-events": "0.1.1",
+        "@radix-ui/react-use-callback-ref": "0.1.0",
+        "@radix-ui/react-use-escape-keydown": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-body-pointer-events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.1.tgz",
+      "integrity": "sha512-R8leV2AWmJokTmERM8cMXFHWSiv/fzOLhG/JLmRBhLTAzOj37EQizssq4oW0Z29VcZy2tODMi9Pk/htxwb+xpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-body-pointer-events/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
+      "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
+      "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.4.tgz",
+      "integrity": "sha512-fbA4ES3H4Wkxp+OeLhvN6SwL7mXNn/aBtUf7DRYxY9+Akrf7dRxl2ck4lgcpPsSg3zSDsEwLcY+h5cmj5yvlug==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
+      "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.4.tgz",
+      "integrity": "sha512-MO0wRy2eYRTZ/CyOri9NANCAtAtq89DEtg90gicaTlkCfdqCLEBsLb+/q66BZQTr3xX/Vq01nnVfc/TkCqoqvw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0",
+        "react-dom": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+      "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
+      "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
     "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dropdown-menu": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-0.1.6.tgz",
@@ -4739,6 +4787,302 @@
       }
     },
     "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-0.1.6.tgz",
+      "integrity": "sha512-zQzgUqW4RQDb0ItAL1xNW4K4olUrkfV3jeEPs9rG+nsDQurO+W9TT+YZ9H1mmgAJqlthyv1sBRZGdBm4YjtD6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-dismissable-layer": "0.1.5",
+        "@radix-ui/react-focus-guards": "0.1.0",
+        "@radix-ui/react-focus-scope": "0.1.4",
+        "@radix-ui/react-id": "0.1.5",
+        "@radix-ui/react-popper": "0.1.4",
+        "@radix-ui/react-portal": "0.1.4",
+        "@radix-ui/react-presence": "0.1.2",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0",
+        "react-dom": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-compose-refs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+      "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+      "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.5.tgz",
+      "integrity": "sha512-J+fYWijkX4M4QKwf9dtu1oC0U6e6CEl8WhBp3Ad23yz2Hia0XCo6Pk/mp5CAFy4QBtQedTSkhW05AdtSOEoajQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-body-pointer-events": "0.1.1",
+        "@radix-ui/react-use-callback-ref": "0.1.0",
+        "@radix-ui/react-use-escape-keydown": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-body-pointer-events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.1.tgz",
+      "integrity": "sha512-R8leV2AWmJokTmERM8cMXFHWSiv/fzOLhG/JLmRBhLTAzOj37EQizssq4oW0Z29VcZy2tODMi9Pk/htxwb+xpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-body-pointer-events/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
+      "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-guards": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
+      "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.4.tgz",
+      "integrity": "sha512-fbA4ES3H4Wkxp+OeLhvN6SwL7mXNn/aBtUf7DRYxY9+Akrf7dRxl2ck4lgcpPsSg3zSDsEwLcY+h5cmj5yvlug==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-id": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
+      "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-0.1.4.tgz",
+      "integrity": "sha512-18gDYof97t8UQa7zwklG1Dr8jIdj3u+rVOQLzPi9f5i1YQak/pVGkaqw8aY+iDUknKKuZniTk/7jbAJUYlKyOw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/popper": "0.1.0",
+        "@radix-ui/react-arrow": "0.1.4",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-rect": "0.1.1",
+        "@radix-ui/react-use-size": "0.1.1",
+        "@radix-ui/rect": "0.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-arrow": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-0.1.4.tgz",
+      "integrity": "sha512-BB6XzAb7Ml7+wwpFdYVtZpK1BlMgqyafSQNGzhIpSZ4uXvXOHPlR5GP8M449JkeQzgQjv9Mp1AsJxFC0KuOtuA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-use-rect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-0.1.1.tgz",
+      "integrity": "sha512-kHNNXAsP3/PeszEmM/nxBBS9Jbo93sO+xuMTcRfwzXsmxT5gDXQzAiKbZQ0EecCPtJIzqvr7dlaQi/aP1PKYqQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/rect": "0.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-use-size": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.1.tgz",
+      "integrity": "sha512-pTgWM5qKBu6C7kfKxrKPoBI2zZYZmp2cSXzpUiGM3qEBQlMLtYhaY2JXdXUCxz+XmD1YEjc8oRwvyfsD4AG4WA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.4.tgz",
+      "integrity": "sha512-MO0wRy2eYRTZ/CyOri9NANCAtAtq89DEtg90gicaTlkCfdqCLEBsLb+/q66BZQTr3xX/Vq01nnVfc/TkCqoqvw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.4",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0",
+        "react-dom": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+      "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
+      "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@tldraw/tldraw/node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
       "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
@@ -5579,16 +5923,16 @@
       }
     },
     "node_modules/@use-gesture/core": {
-      "version": "10.2.16",
-      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.16.tgz",
-      "integrity": "sha512-2J2GICmrSA6RwcowqzL0TY6S8bJY35KhLnE0YjBIVobQL2RilSDefXTKMxxyontp2mALDeeYAHh9ZLu+vMaq8Q=="
+      "version": "10.2.18",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.18.tgz",
+      "integrity": "sha512-O+qxBlKxPtYM/LyRnK/U5MhVA9kKHj4C2yHsUurDxNO0a8D1PHLz9YmMPh2UXGQE4wtSke03GsLqRsHbUvN9nw=="
     },
     "node_modules/@use-gesture/react": {
-      "version": "10.2.16",
-      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.16.tgz",
-      "integrity": "sha512-kkWi97SHzj/F6XqRXSyrk5pLoSiuRgqvnQl2Bawmf05dWo2q6DL7v5LhnnyPNZRVkCm+WEb3e1nsR+iVza1vmg==",
+      "version": "10.2.18",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.18.tgz",
+      "integrity": "sha512-MJQ5q/huXIER3st3bsmuWA7lxcdwZd28KJoBPFPNxKFenjF47smaiCCf+dLjUBiTV0DiIYAN4pXK19KxwfnUgg==",
       "dependencies": {
-        "@use-gesture/core": "10.2.16"
+        "@use-gesture/core": "10.2.18"
       },
       "peerDependencies": {
         "react": ">= 16.8.0"
@@ -13813,9 +14157,9 @@
       }
     },
     "node_modules/mobx": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.0.tgz",
-      "integrity": "sha512-MNTKevLH/6DShLZcmSL351+JgiJPO56A4GUpoiDQ3/yZ0mAtclNLdHK9q4BcQhibx8/JSDupfTpbX2NZPemlRg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.1.tgz",
+      "integrity": "sha512-7su3UZv5JF+ohLr2opabjbUAERfXstMY+wiBtey8yNAPoB8H187RaQXuhFjNkH8aE4iHbDWnhDFZw0+5ic4nGQ==",
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -22137,12 +22481,12 @@
       }
     },
     "@tldraw/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-vXsg6AqoOj3ruaN6+BASla+VX/doaU9mu0R0Px3jzVwZzVPsWwgLaUvl8K0sQ4HzGNip6RX6uOH/TlD1ZLsBuw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-4A9Xyh/VQBCtzVxZF/a7pXkP6AbFqVE8LcD9gmKWnaSYW6haLhc/Ie1O477T5xKV2HMfWJ52x1dUEn3jOGFVCg==",
       "requires": {
         "@tldraw/intersect": "^1.7.1",
-        "@tldraw/vec": "^1.7.0",
+        "@tldraw/vec": "^1.7.1",
         "@use-gesture/react": "^10.2.14",
         "mobx-react-lite": "^3.2.3",
         "perfect-freehand": "^1.1.0",
@@ -22158,19 +22502,21 @@
       }
     },
     "@tldraw/tldraw": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.17.1.tgz",
-      "integrity": "sha512-FUuUpGwuEVRdPJW4pPyRvnKI9l6OKc+sVnzjQFAMppoti9sUnnjgxCE3oQ+GQSjVBKHhCfe+2t7+MaZW9OVN6w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.20.0.tgz",
+      "integrity": "sha512-dVy/l7ceTRwEBzpFvmT2vqDCmbiAJtF55Jv6At9Y9oNDF+xT81dgXupHVw0wSiQRW3ZwD2hxPjnFWqi6uHBS+w==",
       "requires": {
         "@radix-ui/react-alert-dialog": "^0.1.7",
         "@radix-ui/react-context-menu": "^0.1.6",
+        "@radix-ui/react-dialog": "^0.1.7",
         "@radix-ui/react-dropdown-menu": "^0.1.6",
         "@radix-ui/react-icons": "^1.1.1",
+        "@radix-ui/react-popover": "^0.1.6",
         "@radix-ui/react-tooltip": "^0.1.7",
         "@stitches/react": "^1.2.8",
-        "@tldraw/core": "^1.14.0",
+        "@tldraw/core": "^1.15.0",
         "@tldraw/intersect": "^1.7.1",
-        "@tldraw/vec": "^1.7.0",
+        "@tldraw/vec": "^1.7.1",
         "idb-keyval": "^6.1.0",
         "lz-string": "^1.4.4",
         "perfect-freehand": "^1.1.0",
@@ -22209,169 +22555,6 @@
               "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
               "requires": {
                 "@babel/runtime": "^7.13.10"
-              }
-            },
-            "@radix-ui/react-dialog": {
-              "version": "0.1.7",
-              "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-0.1.7.tgz",
-              "integrity": "sha512-jXt8srGhHBRvEr9jhEAiwwJzWCWZoGRJ030aC9ja/gkRJbZdy0iD3FwXf+Ff4RtsZyLUMHW7VUwFOlz3Ixe1Vw==",
-              "requires": {
-                "@babel/runtime": "^7.13.10",
-                "@radix-ui/primitive": "0.1.0",
-                "@radix-ui/react-compose-refs": "0.1.0",
-                "@radix-ui/react-context": "0.1.1",
-                "@radix-ui/react-dismissable-layer": "0.1.5",
-                "@radix-ui/react-focus-guards": "0.1.0",
-                "@radix-ui/react-focus-scope": "0.1.4",
-                "@radix-ui/react-id": "0.1.5",
-                "@radix-ui/react-portal": "0.1.4",
-                "@radix-ui/react-presence": "0.1.2",
-                "@radix-ui/react-primitive": "0.1.4",
-                "@radix-ui/react-slot": "0.1.2",
-                "@radix-ui/react-use-controllable-state": "0.1.0",
-                "aria-hidden": "^1.1.1",
-                "react-remove-scroll": "^2.4.0"
-              },
-              "dependencies": {
-                "@radix-ui/react-dismissable-layer": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.5.tgz",
-                  "integrity": "sha512-J+fYWijkX4M4QKwf9dtu1oC0U6e6CEl8WhBp3Ad23yz2Hia0XCo6Pk/mp5CAFy4QBtQedTSkhW05AdtSOEoajQ==",
-                  "requires": {
-                    "@babel/runtime": "^7.13.10",
-                    "@radix-ui/primitive": "0.1.0",
-                    "@radix-ui/react-compose-refs": "0.1.0",
-                    "@radix-ui/react-primitive": "0.1.4",
-                    "@radix-ui/react-use-body-pointer-events": "0.1.1",
-                    "@radix-ui/react-use-callback-ref": "0.1.0",
-                    "@radix-ui/react-use-escape-keydown": "0.1.0"
-                  },
-                  "dependencies": {
-                    "@radix-ui/react-use-body-pointer-events": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.1.tgz",
-                      "integrity": "sha512-R8leV2AWmJokTmERM8cMXFHWSiv/fzOLhG/JLmRBhLTAzOj37EQizssq4oW0Z29VcZy2tODMi9Pk/htxwb+xpA==",
-                      "requires": {
-                        "@babel/runtime": "^7.13.10",
-                        "@radix-ui/react-use-layout-effect": "0.1.0"
-                      },
-                      "dependencies": {
-                        "@radix-ui/react-use-layout-effect": {
-                          "version": "0.1.0",
-                          "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-                          "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
-                          "requires": {
-                            "@babel/runtime": "^7.13.10"
-                          }
-                        }
-                      }
-                    },
-                    "@radix-ui/react-use-callback-ref": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-                      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
-                      "requires": {
-                        "@babel/runtime": "^7.13.10"
-                      }
-                    },
-                    "@radix-ui/react-use-escape-keydown": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
-                      "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
-                      "requires": {
-                        "@babel/runtime": "^7.13.10",
-                        "@radix-ui/react-use-callback-ref": "0.1.0"
-                      }
-                    }
-                  }
-                },
-                "@radix-ui/react-focus-guards": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
-                  "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
-                  "requires": {
-                    "@babel/runtime": "^7.13.10"
-                  }
-                },
-                "@radix-ui/react-focus-scope": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.4.tgz",
-                  "integrity": "sha512-fbA4ES3H4Wkxp+OeLhvN6SwL7mXNn/aBtUf7DRYxY9+Akrf7dRxl2ck4lgcpPsSg3zSDsEwLcY+h5cmj5yvlug==",
-                  "requires": {
-                    "@babel/runtime": "^7.13.10",
-                    "@radix-ui/react-compose-refs": "0.1.0",
-                    "@radix-ui/react-primitive": "0.1.4",
-                    "@radix-ui/react-use-callback-ref": "0.1.0"
-                  },
-                  "dependencies": {
-                    "@radix-ui/react-use-callback-ref": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-                      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
-                      "requires": {
-                        "@babel/runtime": "^7.13.10"
-                      }
-                    }
-                  }
-                },
-                "@radix-ui/react-id": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
-                  "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
-                  "requires": {
-                    "@babel/runtime": "^7.13.10",
-                    "@radix-ui/react-use-layout-effect": "0.1.0"
-                  },
-                  "dependencies": {
-                    "@radix-ui/react-use-layout-effect": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-                      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
-                      "requires": {
-                        "@babel/runtime": "^7.13.10"
-                      }
-                    }
-                  }
-                },
-                "@radix-ui/react-portal": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.4.tgz",
-                  "integrity": "sha512-MO0wRy2eYRTZ/CyOri9NANCAtAtq89DEtg90gicaTlkCfdqCLEBsLb+/q66BZQTr3xX/Vq01nnVfc/TkCqoqvw==",
-                  "requires": {
-                    "@babel/runtime": "^7.13.10",
-                    "@radix-ui/react-primitive": "0.1.4",
-                    "@radix-ui/react-use-layout-effect": "0.1.0"
-                  },
-                  "dependencies": {
-                    "@radix-ui/react-use-layout-effect": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
-                      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
-                      "requires": {
-                        "@babel/runtime": "^7.13.10"
-                      }
-                    }
-                  }
-                },
-                "@radix-ui/react-use-controllable-state": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
-                  "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
-                  "requires": {
-                    "@babel/runtime": "^7.13.10",
-                    "@radix-ui/react-use-callback-ref": "0.1.0"
-                  },
-                  "dependencies": {
-                    "@radix-ui/react-use-callback-ref": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
-                      "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
-                      "requires": {
-                        "@babel/runtime": "^7.13.10"
-                      }
-                    }
-                  }
-                }
               }
             },
             "@radix-ui/react-primitive": {
@@ -22694,6 +22877,203 @@
             }
           }
         },
+        "@radix-ui/react-dialog": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-0.1.7.tgz",
+          "integrity": "sha512-jXt8srGhHBRvEr9jhEAiwwJzWCWZoGRJ030aC9ja/gkRJbZdy0iD3FwXf+Ff4RtsZyLUMHW7VUwFOlz3Ixe1Vw==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/primitive": "0.1.0",
+            "@radix-ui/react-compose-refs": "0.1.0",
+            "@radix-ui/react-context": "0.1.1",
+            "@radix-ui/react-dismissable-layer": "0.1.5",
+            "@radix-ui/react-focus-guards": "0.1.0",
+            "@radix-ui/react-focus-scope": "0.1.4",
+            "@radix-ui/react-id": "0.1.5",
+            "@radix-ui/react-portal": "0.1.4",
+            "@radix-ui/react-presence": "0.1.2",
+            "@radix-ui/react-primitive": "0.1.4",
+            "@radix-ui/react-slot": "0.1.2",
+            "@radix-ui/react-use-controllable-state": "0.1.0",
+            "aria-hidden": "^1.1.1",
+            "react-remove-scroll": "^2.4.0"
+          },
+          "dependencies": {
+            "@radix-ui/react-compose-refs": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+              "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@radix-ui/react-context": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+              "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@radix-ui/react-dismissable-layer": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.5.tgz",
+              "integrity": "sha512-J+fYWijkX4M4QKwf9dtu1oC0U6e6CEl8WhBp3Ad23yz2Hia0XCo6Pk/mp5CAFy4QBtQedTSkhW05AdtSOEoajQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "0.1.0",
+                "@radix-ui/react-compose-refs": "0.1.0",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-body-pointer-events": "0.1.1",
+                "@radix-ui/react-use-callback-ref": "0.1.0",
+                "@radix-ui/react-use-escape-keydown": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-body-pointer-events": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.1.tgz",
+                  "integrity": "sha512-R8leV2AWmJokTmERM8cMXFHWSiv/fzOLhG/JLmRBhLTAzOj37EQizssq4oW0Z29VcZy2tODMi9Pk/htxwb+xpA==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-use-layout-effect": "0.1.0"
+                  },
+                  "dependencies": {
+                    "@radix-ui/react-use-layout-effect": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+                      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    }
+                  }
+                },
+                "@radix-ui/react-use-callback-ref": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+                  "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                },
+                "@radix-ui/react-use-escape-keydown": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
+                  "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-use-callback-ref": "0.1.0"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-focus-guards": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
+              "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@radix-ui/react-focus-scope": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.4.tgz",
+              "integrity": "sha512-fbA4ES3H4Wkxp+OeLhvN6SwL7mXNn/aBtUf7DRYxY9+Akrf7dRxl2ck4lgcpPsSg3zSDsEwLcY+h5cmj5yvlug==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "0.1.0",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-callback-ref": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-callback-ref": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+                  "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-id": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
+              "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-layout-effect": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-layout-effect": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+                  "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-portal": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.4.tgz",
+              "integrity": "sha512-MO0wRy2eYRTZ/CyOri9NANCAtAtq89DEtg90gicaTlkCfdqCLEBsLb+/q66BZQTr3xX/Vq01nnVfc/TkCqoqvw==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-layout-effect": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-layout-effect": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+                  "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-primitive": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+              "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-slot": "0.1.2"
+              }
+            },
+            "@radix-ui/react-slot": {
+              "version": "0.1.2",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+              "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "0.1.0"
+              }
+            },
+            "@radix-ui/react-use-controllable-state": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
+              "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-callback-ref": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-callback-ref": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+                  "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            }
+          }
+        },
         "@radix-ui/react-dropdown-menu": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-0.1.6.tgz",
@@ -22947,6 +23327,249 @@
                   "version": "0.1.0",
                   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-direction/-/react-use-direction-0.1.0.tgz",
                   "integrity": "sha512-NajpY/An9TCPSfOVkgWIdXJV+VuWl67PxB6kOKYmtNAFHvObzIoh8o0n9sAuwSAyFCZVq211FEf9gvVDRhOyiA==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-primitive": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.4.tgz",
+              "integrity": "sha512-6gSl2IidySupIMJFjYnDIkIWRyQdbu/AHK7rbICPani+LW4b0XdxBXc46og/iZvuwW8pjCS8I2SadIerv84xYA==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-slot": "0.1.2"
+              },
+              "dependencies": {
+                "@radix-ui/react-slot": {
+                  "version": "0.1.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+                  "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-compose-refs": "0.1.0"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-use-controllable-state": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-0.1.0.tgz",
+              "integrity": "sha512-zv7CX/PgsRl46a52Tl45TwqwVJdmqnlQEQhaYMz/yBOD2sx2gCkCFSoF/z9mpnYWmS6DTLNTg5lIps3fV6EnXg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-callback-ref": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-callback-ref": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+                  "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "@radix-ui/react-popover": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-0.1.6.tgz",
+          "integrity": "sha512-zQzgUqW4RQDb0ItAL1xNW4K4olUrkfV3jeEPs9rG+nsDQurO+W9TT+YZ9H1mmgAJqlthyv1sBRZGdBm4YjtD6Q==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/primitive": "0.1.0",
+            "@radix-ui/react-compose-refs": "0.1.0",
+            "@radix-ui/react-context": "0.1.1",
+            "@radix-ui/react-dismissable-layer": "0.1.5",
+            "@radix-ui/react-focus-guards": "0.1.0",
+            "@radix-ui/react-focus-scope": "0.1.4",
+            "@radix-ui/react-id": "0.1.5",
+            "@radix-ui/react-popper": "0.1.4",
+            "@radix-ui/react-portal": "0.1.4",
+            "@radix-ui/react-presence": "0.1.2",
+            "@radix-ui/react-primitive": "0.1.4",
+            "@radix-ui/react-use-controllable-state": "0.1.0",
+            "aria-hidden": "^1.1.1",
+            "react-remove-scroll": "^2.4.0"
+          },
+          "dependencies": {
+            "@radix-ui/react-compose-refs": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
+              "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@radix-ui/react-context": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-0.1.1.tgz",
+              "integrity": "sha512-PkyVX1JsLBioeu0jB9WvRpDBBLtLZohVDT3BB5CTSJqActma8S8030P57mWZb4baZifMvN7KKWPAA40UmWKkQg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@radix-ui/react-dismissable-layer": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-0.1.5.tgz",
+              "integrity": "sha512-J+fYWijkX4M4QKwf9dtu1oC0U6e6CEl8WhBp3Ad23yz2Hia0XCo6Pk/mp5CAFy4QBtQedTSkhW05AdtSOEoajQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "0.1.0",
+                "@radix-ui/react-compose-refs": "0.1.0",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-body-pointer-events": "0.1.1",
+                "@radix-ui/react-use-callback-ref": "0.1.0",
+                "@radix-ui/react-use-escape-keydown": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-body-pointer-events": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.1.tgz",
+                  "integrity": "sha512-R8leV2AWmJokTmERM8cMXFHWSiv/fzOLhG/JLmRBhLTAzOj37EQizssq4oW0Z29VcZy2tODMi9Pk/htxwb+xpA==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-use-layout-effect": "0.1.0"
+                  },
+                  "dependencies": {
+                    "@radix-ui/react-use-layout-effect": {
+                      "version": "0.1.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+                      "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    }
+                  }
+                },
+                "@radix-ui/react-use-callback-ref": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+                  "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                },
+                "@radix-ui/react-use-escape-keydown": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-0.1.0.tgz",
+                  "integrity": "sha512-tDLZbTGFmvXaazUXXv8kYbiCcbAE8yKgng9s95d8fCO+Eundv0Jngbn/hKPhDDs4jj9ChwRX5cDDnlaN+ugYYQ==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-use-callback-ref": "0.1.0"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-focus-guards": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-0.1.0.tgz",
+              "integrity": "sha512-kRx/swAjEfBpQ3ns7J3H4uxpXuWCqN7MpALiSDOXiyo2vkWv0L9sxvbpZeTulINuE3CGMzicVMuNc/VWXjFKOg==",
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@radix-ui/react-focus-scope": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-0.1.4.tgz",
+              "integrity": "sha512-fbA4ES3H4Wkxp+OeLhvN6SwL7mXNn/aBtUf7DRYxY9+Akrf7dRxl2ck4lgcpPsSg3zSDsEwLcY+h5cmj5yvlug==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "0.1.0",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-callback-ref": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-callback-ref": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-0.1.0.tgz",
+                  "integrity": "sha512-Va041McOFFl+aV+sejvl0BS2aeHx86ND9X/rVFmEFQKTXCp6xgUK0NGUAGcgBlIjnJSbMYPGEk1xKSSlVcN2Aw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-id": {
+              "version": "0.1.5",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.5.tgz",
+              "integrity": "sha512-IPc4H/63bes0IZ1GJJozSEkSWcDyhNGtKFWUpJ+XtaLyQ1X3x7Mf6fWwWhDcpqlYEP+5WtAvfqcyEsyjP+ZhBQ==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-layout-effect": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-layout-effect": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+                  "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-popper": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-0.1.4.tgz",
+              "integrity": "sha512-18gDYof97t8UQa7zwklG1Dr8jIdj3u+rVOQLzPi9f5i1YQak/pVGkaqw8aY+iDUknKKuZniTk/7jbAJUYlKyOw==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/popper": "0.1.0",
+                "@radix-ui/react-arrow": "0.1.4",
+                "@radix-ui/react-compose-refs": "0.1.0",
+                "@radix-ui/react-context": "0.1.1",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-rect": "0.1.1",
+                "@radix-ui/react-use-size": "0.1.1",
+                "@radix-ui/rect": "0.1.1"
+              },
+              "dependencies": {
+                "@radix-ui/react-arrow": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-0.1.4.tgz",
+                  "integrity": "sha512-BB6XzAb7Ml7+wwpFdYVtZpK1BlMgqyafSQNGzhIpSZ4uXvXOHPlR5GP8M449JkeQzgQjv9Mp1AsJxFC0KuOtuA==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-primitive": "0.1.4"
+                  }
+                },
+                "@radix-ui/react-use-rect": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-0.1.1.tgz",
+                  "integrity": "sha512-kHNNXAsP3/PeszEmM/nxBBS9Jbo93sO+xuMTcRfwzXsmxT5gDXQzAiKbZQ0EecCPtJIzqvr7dlaQi/aP1PKYqQ==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/rect": "0.1.1"
+                  }
+                },
+                "@radix-ui/react-use-size": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-0.1.1.tgz",
+                  "integrity": "sha512-pTgWM5qKBu6C7kfKxrKPoBI2zZYZmp2cSXzpUiGM3qEBQlMLtYhaY2JXdXUCxz+XmD1YEjc8oRwvyfsD4AG4WA==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                }
+              }
+            },
+            "@radix-ui/react-portal": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-0.1.4.tgz",
+              "integrity": "sha512-MO0wRy2eYRTZ/CyOri9NANCAtAtq89DEtg90gicaTlkCfdqCLEBsLb+/q66BZQTr3xX/Vq01nnVfc/TkCqoqvw==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-primitive": "0.1.4",
+                "@radix-ui/react-use-layout-effect": "0.1.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-use-layout-effect": {
+                  "version": "0.1.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-0.1.0.tgz",
+                  "integrity": "sha512-+wdeS51Y+E1q1Wmd+1xSSbesZkpVj4jsg0BojCbopWvgq5iBvixw5vgemscdh58ep98BwUbsFYnrywFhV9yrVg==",
                   "requires": {
                     "@babel/runtime": "^7.13.10"
                   }
@@ -23670,16 +24293,16 @@
       }
     },
     "@use-gesture/core": {
-      "version": "10.2.16",
-      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.16.tgz",
-      "integrity": "sha512-2J2GICmrSA6RwcowqzL0TY6S8bJY35KhLnE0YjBIVobQL2RilSDefXTKMxxyontp2mALDeeYAHh9ZLu+vMaq8Q=="
+      "version": "10.2.18",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.18.tgz",
+      "integrity": "sha512-O+qxBlKxPtYM/LyRnK/U5MhVA9kKHj4C2yHsUurDxNO0a8D1PHLz9YmMPh2UXGQE4wtSke03GsLqRsHbUvN9nw=="
     },
     "@use-gesture/react": {
-      "version": "10.2.16",
-      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.16.tgz",
-      "integrity": "sha512-kkWi97SHzj/F6XqRXSyrk5pLoSiuRgqvnQl2Bawmf05dWo2q6DL7v5LhnnyPNZRVkCm+WEb3e1nsR+iVza1vmg==",
+      "version": "10.2.18",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.18.tgz",
+      "integrity": "sha512-MJQ5q/huXIER3st3bsmuWA7lxcdwZd28KJoBPFPNxKFenjF47smaiCCf+dLjUBiTV0DiIYAN4pXK19KxwfnUgg==",
       "requires": {
-        "@use-gesture/core": "10.2.16"
+        "@use-gesture/core": "10.2.18"
       }
     },
     "@videojs/http-streaming": {
@@ -29889,9 +30512,9 @@
       }
     },
     "mobx": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.0.tgz",
-      "integrity": "sha512-MNTKevLH/6DShLZcmSL351+JgiJPO56A4GUpoiDQ3/yZ0mAtclNLdHK9q4BcQhibx8/JSDupfTpbX2NZPemlRg==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.6.1.tgz",
+      "integrity": "sha512-7su3UZv5JF+ohLr2opabjbUAERfXstMY+wiBtey8yNAPoB8H187RaQXuhFjNkH8aE4iHbDWnhDFZw0+5ic4nGQ==",
       "peer": true
     },
     "mobx-react-lite": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "homepage": "/playback/presentation/2.3",
   "dependencies": {
-    "@tldraw/tldraw": "^1.16.0",
+    "@tldraw/tldraw": "^1.20.0",
     "classnames": "^2.3.1",
     "darkreader": "^4.9.46",
     "linkify-react": "^3.0.4",

--- a/src/components/tldraw/index.js
+++ b/src/components/tldraw/index.js
@@ -102,9 +102,10 @@ const SlideData = (tldrawAPI) => {
 
 const getCameraAndZoom = (index) => {
   const inactive = {
-    xCamera: 0,
-    yCamera: 0,
-    zoom: 0,
+    height: 0,
+    x: 0,
+    width: 0,
+    y: 0,
   };
 
   if (index === -1) return inactive;
@@ -112,9 +113,10 @@ const getCameraAndZoom = (index) => {
   const currentData = storage.panzooms[index];
 
   return {
-    xCamera: currentData.xCamera,
-    yCamera: currentData.yCamera,
-    zoom: currentData.zoom,
+    height: currentData.height,
+    x: currentData.x,
+    width: currentData.width,
+    y: currentData.y,
   };
 };
 
@@ -130,48 +132,33 @@ const TldrawPresentation = ({ size }) => {
 
   let { assets, shapes } = result;
 
-  const calculateCameraFitSlide = (size, result) => {
-    const { width, height } = result;
-    if (size && width && height) {
-      let zoom = 
-        Math.min(
-          (size.width) / width,
-          (size.height) / height,
-        )        
-        
-      zoom = Utils.clamp(zoom, 0.1, 5);
-    
-      let point = [0, 0];
-      if ((size.width / size.height) > 
-          (width / height)) 
-      { 
-        point[0] = (size.width - (width * zoom)) / 2 / zoom
-      } else {
-        point[1] = (size.height - (height * zoom)) / 2 / zoom
-      }
-    
-      return {point, zoom}
-    } else {
-      return null
-    }
+  const { x, y, width, height } = getCameraAndZoom(currentPanzoomIndex);
+
+  let svgWidth;
+  let svgHeight;
+  svgWidth = (size.height * width) / height;
+  if (size.height < svgWidth) {
+    svgHeight = (size.height * size.width) / svgWidth;
+    svgWidth = size.width;
+  } else {
+    svgHeight = size.height;
   }
 
   React.useEffect(() => {
-    const { xCamera, yCamera, zoom } = getCameraAndZoom(currentPanzoomIndex);
-    if (xCamera === 0 && yCamera === 0 && zoom === 0) {
-      const camera = calculateCameraFitSlide(size, result);
-      if (camera) {
-        tldrawAPI?.setCamera(camera.point, camera.zoom);
-      }
-    } else {
-      tldrawAPI?.setCamera([xCamera, yCamera], zoom);
-    }
-  }, [currentPanzoomIndex, currentSlideIndex, tldrawAPI, size, result]);
+    let zoom = 
+      Math.min(
+        (svgWidth) / width,
+        (svgHeight) / height
+      );
+
+    tldrawAPI?.setCamera([x, y], zoom);
+
+  }, [svgWidth, svgHeight, width, height, x, y, currentSlideIndex, tldrawAPI, size, result]);
   
   React.useEffect(() => {
     tldrawAPI?.replacePageContent(shapes, {}, assets)
   }, [tldrawAPI, shapes, assets]);
- 
+
   return (
     <div
       aria-label={intl.formatMessage(intlMessages.aria)}
@@ -180,18 +167,38 @@ const TldrawPresentation = ({ size }) => {
     >
       {!started 
         ? <div className={cx('presentation', 'logo')}/>
-        : <div className={'presentation'}>
+        : <div className={'presentation'}
+            style={{
+              position: 'absolute',
+              width: svgWidth < 0 ? 0 : svgWidth,
+              height: svgHeight < 0 ? 0 : svgHeight,
+          }}>
             <Cursor tldrawAPI={tldrawAPI} size={size}/>
             <Tldraw          
               disableAssets={true}
+              autofocus={false}
               showPages={false}
-              showZoom={true}
+              showZoom={false}
               showUI={false}
               showMenu={false}
               showMultiplayerMenu={false}
               readOnly={true}
               onMount={(app) => {
+                app.onPan = () => {};
+                app.setSelectedIds = () => {};
+                app.setHoveredId = () => {};
                 setTLDrawAPI(app);
+              }}
+              //don't allow pan&zoom
+              onPatch={(e, t, reason) => {
+                if (reason && (reason.includes("zoomed") || reason.includes("panned"))) {
+                  let zoom = 
+                    Math.min(
+                      (svgWidth) / width,
+                      (svgHeight) / height
+                    );
+                  tldrawAPI?.setCamera([x, y], zoom);
+                }
               }}
             />
           </div>

--- a/src/components/tldraw/index.scss
+++ b/src/components/tldraw/index.scss
@@ -16,3 +16,7 @@
   height: 100%;
   width: 100%;
 }
+
+#TD-ContextMenu {
+  display: none;
+}

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -366,25 +366,14 @@ const buildPanzooms = result => {
   if (hasProperty(recording, 'event')) {
     const tldraw = recording._tldraw === 'true';
     data = convertToArray(recording.event).map(panzoom => {
-      if (!tldraw) {
-        const viewbox = getNumbers(panzoom.viewBox);
-        return {
-          timestamp: parseFloat(panzoom._timestamp),
-          x: viewbox.shift(),
-          y: viewbox.shift(),
-          width: viewbox.shift(),
-          height: viewbox.shift(),
-        };
-      }
-      else {
-        const cameraAndZoom = getNumbers(panzoom.cameraAndZoom);
-        return {
-          timestamp: parseFloat(panzoom._timestamp),
-          xCamera: cameraAndZoom.shift(),
-          yCamera: cameraAndZoom.shift(),
-          zoom: cameraAndZoom.shift(),
-        };
-      }
+      const viewbox = getNumbers(panzoom.viewBox);
+      return {
+        timestamp: parseFloat(panzoom._timestamp),
+        x: viewbox.shift(),
+        y: viewbox.shift(),
+        width: viewbox.shift(),
+        height: viewbox.shift(),
+      };
     });
     data.tldraw = tldraw;
   }


### PR DESCRIPTION
- Uses the updated pan&zoom event (https://github.com/bigbluebutton/bigbluebutton/pull/15583) to only show the portion of the slide according to the viewbox
- Update tldraw version
- Don't allow pan&zoom and hovering/selecting on itens
- Hide context menu (right click)

Need the updated pan&zoom event from:
https://github.com/bigbluebutton/bigbluebutton/pull/15583

Closes #210 