### PR TITLE
fix(tldraw): moved to back shapes lost behind slide

### DIFF
--- a/src/components/tldraw/index.js
+++ b/src/components/tldraw/index.js
@@ -67,7 +67,7 @@ const SlideData = (tldrawAPI) => {
 
   shapes["slide-background-shape"] = {
     assetId: `slide-background-asset-${id}`,
-    childIndex: 0.5,
+    childIndex: -1,
     id: "slide-background-shape",
     name: "Image",
     type: TDShapeType.Image,


### PR DESCRIPTION
Decrease background slide index so other shapes can't be hidden behind it.