### PR TITLE
fix(poll): show number of votes and group answers

### DIFF
--- a/src/components/chat/messages/system/poll/result.js
+++ b/src/components/chat/messages/system/poll/result.js
@@ -35,7 +35,7 @@ const Result = ({
 
         return(
           <div className="poll-label">
-            {id + 1}: <span className="poll-bar">{getBar(percentage)}</span> {percentage}%
+            {id + 1}: {numVotes} <span className="poll-bar">{getBar(percentage)}</span> {percentage}%
           </div>
         );
       })}

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -1,6 +1,6 @@
 import { parseFromString } from './data/xml2json';
 import { files as config } from 'config';
-import { getFileType } from './data';
+import { getFileType, caseInsensitiveReducer } from './data';
 import {
   hasProperty,
   isEmpty,
@@ -89,9 +89,14 @@ const buildCaptions = result => {
 // TODO
 const buildPolls = result => {
   if (!result) return [];
-
-  let data = [];
-  data = result;
+  
+  const data = result.map(r => {
+    const answers = r.answers.reduce(caseInsensitiveReducer, []);
+    return {
+      ...r,
+      answers,
+    };
+  });
 
   return data;
 };

--- a/src/utils/data/index.js
+++ b/src/utils/data/index.js
@@ -161,6 +161,21 @@ const getMessageType = (item) => {
 
 const getTimestampAsMilliseconds = timestamp => timestamp * 1000;
 
+const caseInsensitiveReducer = (acc, item) => {
+  const index = acc.findIndex(ans => ans.key.toLowerCase() === item.key.toLowerCase());
+  if(index !== -1) {
+    if(acc[index].numVotes >= item.numVotes) acc[index].numVotes += item.numVotes;
+    else {
+      const tempVotes = acc[index].numVotes;
+      acc[index] = item;
+      acc[index].numVotes += tempVotes;
+    }
+  } else {
+    acc.push(item);
+  }
+  return acc;
+};
+
 export {
   buildFileURL,
   getAvatarStyle,
@@ -173,4 +188,5 @@ export {
   getPercentage,
   getPollLabel,
   getTimestampAsMilliseconds,
+  caseInsensitiveReducer
 };


### PR DESCRIPTION
Fix the poll chat message to be consistent to what is shown in the live meeting:

- Show the number of votes for each answer in the poll chat message.
- Group chat messages case insensitive

![poll_group](https://user-images.githubusercontent.com/2726293/210835860-34479939-3001-4d69-a7d9-9533e75a4b87.png)

Fixes #218 