### PR TITLE
chore: bump tldraw to 1.27.0 to match client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@tldraw/tldraw": "^1.26.4",
+        "@tldraw/tldraw": "^1.27.0",
         "classnames": "^2.3.1",
         "darkreader": "^4.9.46",
         "linkify-react": "^3.0.4",
@@ -4507,9 +4507,9 @@
       }
     },
     "node_modules/@tldraw/core": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.20.3.tgz",
-      "integrity": "sha512-R/HqtQOg8yedcN70m75ekdm2u6dAHQpg3uxmzd7/TsdUnbfZc5UMp3TakYlTD6JwSSRV0n2huI4AD8D/NJ5jEw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-3hvYLR/XwpMI9GvHIHGfYNmkiaKlokx8vekx0Eq/o/NAkqGkGwnZcTG5shbetWzwQTTi5F4vWInJqA/BfX+OCA==",
       "dependencies": {
         "@tldraw/intersect": "^1.8.0",
         "@tldraw/vec": "^1.8.0",
@@ -4530,9 +4530,9 @@
       }
     },
     "node_modules/@tldraw/tldraw": {
-      "version": "1.26.4",
-      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.26.4.tgz",
-      "integrity": "sha512-hD1lyM+TvaWkAtDKRXHu3Vt2a7OhJOlyEeaNoe0Nhgxb8BbrcdS8sTPKYL4CWjKmdFjYJ2ZfPlaiF2Dzvwk3JA==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.27.0.tgz",
+      "integrity": "sha512-ukN1EzLJxDutoo3ZOPZEfEgKUOt+St5yO8P/HSpJF+/QWDEzVrEttZGXOpny02R30tb96rdjtNQEex8TzUjzIQ==",
       "dependencies": {
         "@fontsource/caveat-brush": "^4.5.9",
         "@fontsource/crimson-pro": "^4.5.10",
@@ -4547,7 +4547,7 @@
         "@radix-ui/react-popover": "^1.0.0",
         "@radix-ui/react-tooltip": "^1.0.0",
         "@stitches/react": "^1.2.8",
-        "@tldraw/core": "^1.20.3",
+        "@tldraw/core": "^1.21.0",
         "@tldraw/intersect": "^1.8.0",
         "@tldraw/vec": "^1.8.0",
         "browser-fs-access": "^0.31.0",
@@ -5151,16 +5151,16 @@
       }
     },
     "node_modules/@use-gesture/core": {
-      "version": "10.2.18",
-      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.18.tgz",
-      "integrity": "sha512-O+qxBlKxPtYM/LyRnK/U5MhVA9kKHj4C2yHsUurDxNO0a8D1PHLz9YmMPh2UXGQE4wtSke03GsLqRsHbUvN9nw=="
+      "version": "10.2.23",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.23.tgz",
+      "integrity": "sha512-Ynap/Uh6RX1Vgn3zNmFTyKapapdf7Av+GzAe6h+RsBZaxMF1z3cK6aohHPJP6T1hLrPyH/yehxa7RBqyESG9RA=="
     },
     "node_modules/@use-gesture/react": {
-      "version": "10.2.18",
-      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.18.tgz",
-      "integrity": "sha512-MJQ5q/huXIER3st3bsmuWA7lxcdwZd28KJoBPFPNxKFenjF47smaiCCf+dLjUBiTV0DiIYAN4pXK19KxwfnUgg==",
+      "version": "10.2.23",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.23.tgz",
+      "integrity": "sha512-anj9j3Lm4l+/s60Jv1FD2m13r+T+aYstSHUT62hTugojM64LPe9XatfEVHRyWOrGjRU2buQhlm03xN8oxkg/OQ==",
       "dependencies": {
-        "@use-gesture/core": "10.2.18"
+        "@use-gesture/core": "10.2.23"
       },
       "peerDependencies": {
         "react": ">= 16.8.0"
@@ -22307,9 +22307,9 @@
       }
     },
     "@tldraw/core": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.20.3.tgz",
-      "integrity": "sha512-R/HqtQOg8yedcN70m75ekdm2u6dAHQpg3uxmzd7/TsdUnbfZc5UMp3TakYlTD6JwSSRV0n2huI4AD8D/NJ5jEw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-3hvYLR/XwpMI9GvHIHGfYNmkiaKlokx8vekx0Eq/o/NAkqGkGwnZcTG5shbetWzwQTTi5F4vWInJqA/BfX+OCA==",
       "requires": {
         "@tldraw/intersect": "^1.8.0",
         "@tldraw/vec": "^1.8.0",
@@ -22326,9 +22326,9 @@
       }
     },
     "@tldraw/tldraw": {
-      "version": "1.26.4",
-      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.26.4.tgz",
-      "integrity": "sha512-hD1lyM+TvaWkAtDKRXHu3Vt2a7OhJOlyEeaNoe0Nhgxb8BbrcdS8sTPKYL4CWjKmdFjYJ2ZfPlaiF2Dzvwk3JA==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@tldraw/tldraw/-/tldraw-1.27.0.tgz",
+      "integrity": "sha512-ukN1EzLJxDutoo3ZOPZEfEgKUOt+St5yO8P/HSpJF+/QWDEzVrEttZGXOpny02R30tb96rdjtNQEex8TzUjzIQ==",
       "requires": {
         "@fontsource/caveat-brush": "^4.5.9",
         "@fontsource/crimson-pro": "^4.5.10",
@@ -22343,7 +22343,7 @@
         "@radix-ui/react-popover": "^1.0.0",
         "@radix-ui/react-tooltip": "^1.0.0",
         "@stitches/react": "^1.2.8",
-        "@tldraw/core": "^1.20.3",
+        "@tldraw/core": "^1.21.0",
         "@tldraw/intersect": "^1.8.0",
         "@tldraw/vec": "^1.8.0",
         "browser-fs-access": "^0.31.0",
@@ -22834,15 +22834,16 @@
       }
     },
     "@use-gesture/core": {
-      "version": "10.2.18",
-      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.18.tgz",
-      "integrity": "sha512-O+qxBlKxPtYM/LyRnK/U5MhVA9kKHj4C2yHsUurDxNO0a8D1PHLz9YmMPh2UXGQE4wtSke03GsLqRsHbUvN9nw=="
+      "version": "10.2.23",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.23.tgz",
+      "integrity": "sha512-Ynap/Uh6RX1Vgn3zNmFTyKapapdf7Av+GzAe6h+RsBZaxMF1z3cK6aohHPJP6T1hLrPyH/yehxa7RBqyESG9RA=="
     },
     "@use-gesture/react": {
-      "version": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.18.tgz",
-      "integrity": "sha512-MJQ5q/huXIER3st3bsmuWA7lxcdwZd28KJoBPFPNxKFenjF47smaiCCf+dLjUBiTV0DiIYAN4pXK19KxwfnUgg==",
+      "version": "10.2.23",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.23.tgz",
+      "integrity": "sha512-anj9j3Lm4l+/s60Jv1FD2m13r+T+aYstSHUT62hTugojM64LPe9XatfEVHRyWOrGjRU2buQhlm03xN8oxkg/OQ==",
       "requires": {
-        "@use-gesture/core": "10.2.18"
+        "@use-gesture/core": "10.2.23"
       }
     },
     "@videojs/http-streaming": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "homepage": "/playback/presentation/2.3",
   "dependencies": {
-    "@tldraw/tldraw": "^1.26.4",
+    "@tldraw/tldraw": "^1.27.0",
     "classnames": "^2.3.1",
     "darkreader": "^4.9.46",
     "linkify-react": "^3.0.4",


### PR DESCRIPTION
Matching the version of the client, upgraded via https://github.com/bigbluebutton/bigbluebutton/pull/16487