### PR TITLE
fix(tldraw): video tooltips/volume behind presentation

### DIFF
--- a/src/components/tldraw/index.scss
+++ b/src/components/tldraw/index.scss
@@ -9,6 +9,7 @@
   position: absolute;
   top: 0;
   width: 100%;
+  z-index: 0;
 }
 
 .presentation {


### PR DESCRIPTION
decrease tldraw zindex so it statys behind video controls

Before:
![before_full](https://user-images.githubusercontent.com/2726293/215467662-59715936-cb14-4cc7-9b11-220e4ee2debb.png)

After:
![after_full](https://user-images.githubusercontent.com/2726293/215467684-99e4a33c-3aff-4399-a620-f7441a9e6479.png)
