### PR TITLE
fix: ios safari infinite loader and time parameter

### DIFF
--- a/src/components/screenshare/index.js
+++ b/src/components/screenshare/index.js
@@ -52,6 +52,7 @@ const Screenshare = () => {
       if (!video) return;
 
       player.screenshare = videojs(video, buildOptions(sources), () => {});
+      player.screenshare.pause();
       logger.debug(ID.SCREENSHARE, 'mounted');
     }
   }, []);
@@ -77,6 +78,7 @@ const Screenshare = () => {
           className="video-js"
           playsInline
           preload="auto"
+          autoPlay
           ref={element}
         />
       </div>

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -158,6 +158,7 @@ const Webcams = () => {
           className="video-js"
           playsInline
           preload="auto"
+          autoPlay
           ref={element}
         />
       </div>


### PR DESCRIPTION
## Fix iOS safari infinite loader and time parameter

_I noticed that in version 4.+ in mobile safari, simultaneous playback of the screen share and a webcam did not work. In version 5.0.0, this bug was fixed (or I updated ios), but in some cases in safari, when opening the page, the loader remained even after loading all the resources. There was also the bug with the `t` parameter #80_ 

### Docs

I think it's related to safari webkit. Safari does not allow you to play more than one `<video>` with sound on the page. 
Here are links to explore: [webkit bugs](https://bugs.webkit.org/show_bug.cgi?id=162366), [webkit blog](https://webkit.org/blog/6784/new-video-policies-for-ios/), [possible solution](https://www.zegocloud.com/docs/video-call/restriction-multiple-videos-safari?platform=web&language=javascript) 

### Added

- `autoPlay` attribute  to screen share and webcam `<video>`
- `pause()` after screen share initialization to prevent immediately screen share playback