### PR TITLE
Put a space before URL in chat messages

### DIFF
--- a/src/components/chat/messages/user/text.js
+++ b/src/components/chat/messages/user/text.js
@@ -28,7 +28,7 @@ const Text = ({
 
     return (
       <Linkify options={options}>
-        {text}
+        {text.replace(/(\S)(https?:\/\/)/g, '$1 $2')}
       </Linkify>
     );
   }


### PR DESCRIPTION
This patch introduces a space before URL in chat messages only when there is no space there.
It improves how the link is displayed during the playback, especially when Japanese (or maybe other Asian letters) text is combined.

Here is the closed issue report that I mistakenly posted on BigBlueButton project:
https://github.com/bigbluebutton/bigbluebutton/issues/18313