### PR TITLE
fix: whiteboard annotations appearing in all slides.

### DIFF
--- a/src/components/tldraw/index.js
+++ b/src/components/tldraw/index.js
@@ -149,7 +149,6 @@ const TldrawPresentation = ({ size }) => {
   const currentSlideIndex = useCurrentIndex(storage.slides);
   const started = currentPanzoomIndex !== -1;
 
-  console.log("Teste aqui antes do SlideData: \n\n\n\n\n", tldrawAPI);
   const result = SlideData(tldrawAPI);
 
   let { assets, shapes, scaleRatio } = result;

--- a/src/components/tldraw/index.js
+++ b/src/components/tldraw/index.js
@@ -36,7 +36,7 @@ const intlMessages = defineMessages({
   },
 });
 
-const getTldrawData = (index, pageId) => storage.tldraw[index].id === pageId.toString() 
+const getTldrawData = (index, pageNumber) => storage.tldraw[index].id === pageNumber.toString() 
   ? storage.tldraw[index].data : [];
 const getTldrawBbbVersion = (index) => storage.tldraw[index]?.bbb_version;
 
@@ -149,6 +149,7 @@ const TldrawPresentation = ({ size }) => {
   const currentSlideIndex = useCurrentIndex(storage.slides);
   const started = currentPanzoomIndex !== -1;
 
+  console.log("Teste aqui antes do SlideData: \n\n\n\n\n", tldrawAPI);
   const result = SlideData(tldrawAPI);
 
   let { assets, shapes, scaleRatio } = result;

--- a/src/components/tldraw/index.js
+++ b/src/components/tldraw/index.js
@@ -36,7 +36,8 @@ const intlMessages = defineMessages({
   },
 });
 
-const getTldrawData = (index) => storage.tldraw[index].data;
+const getTldrawData = (index, pageId) => storage.tldraw[index].id === pageId.toString() 
+  ? storage.tldraw[index].data : [];
 const getTldrawBbbVersion = (index) => storage.tldraw[index]?.bbb_version;
 
 const SlideData = (tldrawAPI) => {
@@ -103,14 +104,16 @@ const SlideData = (tldrawAPI) => {
   for (let i = 0; i < interval.length; i++) {
     if (!interval[i]) continue;
 
-    const tldrawData = getTldrawData(index);
+    const tldrawData = getTldrawData(index, id);
 
-    const {
-      shape,
-    } = tldrawData[i];
-
-    shape.parentId = tldrawAPI?.currentPageId;
-    shapes[shape.id] = shape;
+    if (tldrawData[i]) {
+      const {
+        shape,
+      } = tldrawData[i];
+  
+      shape.parentId = tldrawAPI?.currentPageId;
+      shapes[shape.id] = shape; 
+    }
   }
 
   return { assets, shapes, scaleRatio }


### PR DESCRIPTION
### What does this PR do?

This fixes the whiteboard annotations to be displayed only in the slides they were made.

### Closes:

Closes https://github.com/bigbluebutton/bigbluebutton/issues/18721

### More:

To test this PR, one can run the `./deploy.sh` [script](https://github.com/bigbluebutton/bbb-playback/blob/develop/deploy.sh) which will make a bundle out of the playback folder and place it in the correct directory. Despite this comfort automated script's build, the last part of it must be commented out because, since there is already an NGINX file correctly configured for playback in `/usr/share/bigbluebutton/nginx/playback.nginx`, and so if the last part of the script runs, it will also place the NGINX configuration file in `/etc/bigbluebutton/nginx/playback.nginx` which will crash NGINX. Hence, the `deploy.sh` will look like the following:

```bash
#!/bin/bash

set -e

BBB_PLAYBACK_HOMEPAGE=playback/presentation/2.3
BBB_PLAYBACK=/var/bigbluebutton/$BBB_PLAYBACK_HOMEPAGE

export REACT_APP_BBB_PLAYBACK_BUILD=$(git rev-parse --short HEAD)

npm run-script build
sudo rm -rf $BBB_PLAYBACK
sudo cp -r ./build $BBB_PLAYBACK
sudo chown --recursive bigbluebutton:bigbluebutton $BBB_PLAYBACK

#BBB_NGINX_FILES_PATH=/etc/bigbluebutton/nginx
#if [ ! -f $BBB_NGINX_FILES_PATH/playback.nginx ]; then
#  sudo cp ./playback.nginx $BBB_NGINX_FILES_PATH
#  sudo systemctl reload nginx
#fi

```

Then just follow the instructions on the issue mentioned here to try and reproduce the error, it should not happen anymore.