### PR TITLE
fix: change nginx path in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ sudo rm -rf $BBB_PLAYBACK
 sudo cp -r ./build $BBB_PLAYBACK
 sudo chown --recursive bigbluebutton:bigbluebutton $BBB_PLAYBACK
 
-BBB_NGINX_FILES_PATH=/usr/share/bigbluebutton/nginx/
+BBB_NGINX_FILES_PATH=/usr/share/bigbluebutton/nginx
 if [ ! -f $BBB_NGINX_FILES_PATH/playback.nginx ]; then
   sudo cp ./playback.nginx $BBB_NGINX_FILES_PATH
   sudo systemctl reload nginx

--- a/deploy.sh
+++ b/deploy.sh
@@ -12,7 +12,7 @@ sudo rm -rf $BBB_PLAYBACK
 sudo cp -r ./build $BBB_PLAYBACK
 sudo chown --recursive bigbluebutton:bigbluebutton $BBB_PLAYBACK
 
-BBB_NGINX_FILES_PATH=/etc/bigbluebutton/nginx
+BBB_NGINX_FILES_PATH=/usr/share/bigbluebutton/nginx/
 if [ ! -f $BBB_NGINX_FILES_PATH/playback.nginx ]; then
   sudo cp ./playback.nginx $BBB_NGINX_FILES_PATH
   sudo systemctl reload nginx


### PR DESCRIPTION
The nginx files were moved in BBB ~2.6. Without this change I get nginx errors when deploying --

```
Nov 09 10:54:43 anton-droplet-5892 nginx[70906]: nginx: [emerg] duplicate location "/playback/presentation/2.3" in /etc/bigbluebutton/nginx/playback.nginx:1
Nov 09 10:54:43 anton-droplet-5892 systemd[1]: nginx.service: Control process exited, code=exited, status=1/FAILURE
```


```
root@anton-droplet-5892:/etc/bigbluebutton/nginx# locate playback\.nginx
/etc/bigbluebutton/nginx/playback.nginx
/usr/share/bigbluebutton/nginx/playback.nginx
```