### PR TITLE
Fix loading slide images from a relative directory in tldraw v2

### DIFF
--- a/src/components/tldraw/index.js
+++ b/src/components/tldraw/index.js
@@ -56,12 +56,6 @@ const SlideData = (tldrawAPI) => {
     width,
   } = storage.slides[currentIndex];
 
-  let imageUrl = buildFileURL(src);
-  // tldraw needs the full address as src
-  if (!imageUrl.startsWith("http")) {
-    imageUrl = window.location.origin + imageUrl;
-  }
-
   const bbbVersion = getTldrawBbbVersion(index);
   if (bbbVersion && semverGte(bbbVersion, '2.6.1')) {
     MAX_IMAGE_WIDTH = 1440;

--- a/src/components/tldraw_v2/index.js
+++ b/src/components/tldraw_v2/index.js
@@ -51,13 +51,6 @@ const SlideData = (tldrawAPI) => {
     width,
   } = storage.slides[currentIndex];
 
-  let imageUrl = buildFileURL(src);
-
-  // Tldraw neeed the full address as the source
-  if (!imageUrl.startsWith("http")) {
-    imageUrl = window.location.origin + imageUrl;
-  }
-
   const scaleRatio = Math.min(MAX_IMAGE_WIDTH / width, MAX_IMAGE_HEIGHT / height);
   const scaledWidth = width * scaleRatio;
   const scaledHeight = height * scaleRatio;
@@ -65,7 +58,7 @@ const SlideData = (tldrawAPI) => {
   const curPageId = tldrawAPI?.getCurrentPageId();
   const assetId = AssetRecordType.createId(curPageId);
   
-  assets[`slide-background-asset-${id}`] = createTldrawImageAsset(assetId, imageUrl, scaledWidth, scaledHeight)
+  assets[`slide-background-asset-${id}`] = createTldrawImageAsset(assetId, buildFileURL(src), scaledWidth, scaledHeight)
   shapes["slide-background-shape"] = createTldrawBackgroundShape(assetId, curPageId, scaledWidth, scaledHeight)
 
   if (index === -1 || isEmpty(interval)) return { assets, shapes, scaleRatio }


### PR DESCRIPTION
The tldraw v2 code was prepending the origin of the current page to the slide image urls, if they didn't start with "http". This resulted in it generating invalid URLs that look like:
`https://example.compresentation/ea5b16cd4eef022e866b1462aed02a43342a80a8-1726509771537/svgs/slide1.svg` when the playback is compiled to load from a relative URL (i.e. with `REACT_APP_NO_ROUTER=1 PUBLIC_URL=.` )

The cause appears to be that some dead code (assignment to an unused variable) was copied from the tldraw v1 code, and then code later in the file was adjusted to use that variable, making its behaviour differ from tldraw v1.

Remove the unused code from tldraw v1, and adjust tldraw v2 to match the behaviour of tldraw v1.