### PR TITLE
Fix client crash when reactions is undefined.

### DIFF
--- a/src/components/chat/messages/message.js
+++ b/src/components/chat/messages/message.js
@@ -31,6 +31,7 @@ const defaultProps = {
   initials: '',
   name: '',
   timestamp: 0,
+  reactions: [],
 };
 
 const Message = ({


### PR DESCRIPTION
This can happen when loading a recording created on a BBB 2.7 server.

This fixes an "ERROR: reactions is undefined" which occurs on this line of code: https://github.com/bigbluebutton/bbb-playback/blob/4aaa3a034895c66de33caa8dd22f219183fe0765/src/components/chat/messages/reactions/index.js#L13