### PR TITLE
chore: bump tldraw to 2.0.0-alpha.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.3.0",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@bigbluebutton/tldraw": "^2.0.0-alpha.25",
+        "@bigbluebutton/tldraw": "^2.0.0-alpha.27",
         "bowser": "^2.11.0",
         "classnames": "^2.3.1",
         "darkreader": "^4.9.46",
@@ -2008,16 +2008,16 @@
       "dev": true
     },
     "node_modules/@bigbluebutton/editor": {
-      "version": "2.0.0-alpha.24",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/editor/-/editor-2.0.0-alpha.24.tgz",
-      "integrity": "sha512-bLhnBpuVo3YqtWktPY8I1nZ4A/eZ7WZP9hDfE+BmSc2ZGwAl0TIzzcUQKBoWAkA0I85ir7/Xim3fAZZm2lbK7Q==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/editor/-/editor-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-zS/ZhcTEN0FLnvBLDY1rAW5coeU+e0v1VQKDlgQ06ylIviYibntfB/SoYU/xPPW0oZhypuaZfunvz3zT9nSDKA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bigbluebutton/state": "2.0.0-alpha.21",
-        "@bigbluebutton/store": "2.0.0-alpha.21",
-        "@bigbluebutton/tlschema": "2.0.0-alpha.21",
-        "@bigbluebutton/utils": "2.0.0-alpha.21",
-        "@bigbluebutton/validate": "2.0.0-alpha.21",
+        "@bigbluebutton/state": "2.0.0-alpha.27",
+        "@bigbluebutton/store": "2.0.0-alpha.27",
+        "@bigbluebutton/tlschema": "2.0.0-alpha.27",
+        "@bigbluebutton/utils": "2.0.0-alpha.27",
+        "@bigbluebutton/validate": "2.0.0-alpha.27",
         "@types/core-js": "^2.5.5",
         "@use-gesture/react": "^10.2.27",
         "classnames": "^2.3.2",
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@bigbluebutton/state": {
-      "version": "2.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/state/-/state-2.0.0-alpha.21.tgz",
-      "integrity": "sha512-yioRXoBWzPtLZdzO0rCxaymfBewDmZ3098F6drncFz++InACBzmaqhZXXkAZFxLtsTwQQi4wL8vw9uYgcES8vA==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/state/-/state-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-pqYNi0r952K1z2Q5RCpcjIa6CiX0+GIABE5Gv9BJnlCviTw2OHkG+0SpGQxg2ON5Tu1M3H650ZxKlJJ0S2Q07w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@testing-library/react": "^16.0.0"
@@ -2064,14 +2064,41 @@
         "react": "^18"
       }
     },
+    "node_modules/@bigbluebutton/state/node_modules/@testing-library/react": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bigbluebutton/store": {
-      "version": "2.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/store/-/store-2.0.0-alpha.21.tgz",
-      "integrity": "sha512-cgBcekfkW0AZMCVCNpopfuGEmlEziqQI1bnUdbOZAA8aWCTG5/WuqM9anknZKccg+Dvfr2d/g2FcCSMKDlUH4w==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/store/-/store-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-V4dFMMnH26aF/pJddrmY+qzewSBhOXkD85qyxCtlhFiHaFvaGuzmiMhetclJgsYuFZTKSSNKN+Ps81qIUZMvRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bigbluebutton/state": "2.0.0-alpha.21",
-        "@bigbluebutton/utils": "2.0.0-alpha.21",
+        "@bigbluebutton/state": "2.0.0-alpha.27",
+        "@bigbluebutton/utils": "2.0.0-alpha.27",
         "lodash.isequal": "^4.5.0",
         "nanoid": "4.0.2"
       }
@@ -2095,12 +2122,12 @@
       }
     },
     "node_modules/@bigbluebutton/tldraw": {
-      "version": "2.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/tldraw/-/tldraw-2.0.0-alpha.25.tgz",
-      "integrity": "sha512-0DlcHUOryCxhNmZhvXXJNaOi1N99F00OPJj6HHnTXlf/qAIRFBWJn6o1w288ORRULL6gE9WVG2K7+xuN17zaew==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/tldraw/-/tldraw-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-ce3YwiHRAryyiKcLyXnn9SCNAZFMjCssWLgOfXN1slIBrRciyQxQ41sHsgMszKmZjnbN3+efTqWF7FiqKmTeXA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bigbluebutton/editor": "2.0.0-alpha.24",
+        "@bigbluebutton/editor": "2.0.0-alpha.27",
         "@radix-ui/react-alert-dialog": "^1.0.0",
         "@radix-ui/react-context-menu": "^2.1.5",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -2444,15 +2471,15 @@
       }
     },
     "node_modules/@bigbluebutton/tlschema": {
-      "version": "2.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/tlschema/-/tlschema-2.0.0-alpha.21.tgz",
-      "integrity": "sha512-redk2SmrU8hG0Rwl4cYn8mkp4iqT0Bk3A3pmlqMuI+c0O1r6Ko41C0gviKqfHRlnNqObq5JcYFirxc/UO+L75g==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/tlschema/-/tlschema-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-1ZVlwucbqCPYy8XXiYBBppsPZnz2Wa4mznJaFDw57dGVMsnadf4VpgB8n0h0zXF/LSQwH/7nZwN9OZkuO9/4Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bigbluebutton/state": "2.0.0-alpha.21",
-        "@bigbluebutton/store": "2.0.0-alpha.21",
-        "@bigbluebutton/utils": "2.0.0-alpha.21",
-        "@bigbluebutton/validate": "2.0.0-alpha.21",
+        "@bigbluebutton/state": "2.0.0-alpha.27",
+        "@bigbluebutton/store": "2.0.0-alpha.27",
+        "@bigbluebutton/utils": "2.0.0-alpha.27",
+        "@bigbluebutton/validate": "2.0.0-alpha.27",
         "nanoid": "4.0.2"
       }
     },
@@ -2475,18 +2502,18 @@
       }
     },
     "node_modules/@bigbluebutton/utils": {
-      "version": "2.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/utils/-/utils-2.0.0-alpha.21.tgz",
-      "integrity": "sha512-4Cc90N6HJMTdCtk8lm9mTEI6oBF3Sg3b1rWLeSNWCIfCed/lrfilTw80PrskGzznwkWkGbtmFCE9vQmpB6Ppbg==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/utils/-/utils-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-pO6lSdnBC/AZZsRrUx7ClY7Uaivp2ibZj1vHVrgbNAJyIrEGODunYkNyzs9JDxnj0IyQvgPuHQJ3oNAzgBEluQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@bigbluebutton/validate": {
-      "version": "2.0.0-alpha.21",
-      "resolved": "https://registry.npmjs.org/@bigbluebutton/validate/-/validate-2.0.0-alpha.21.tgz",
-      "integrity": "sha512-fQ7DBLPVCos1HMCC8KA52Lhm4uRAdg3PCsUuAU+fgHF2sMzuCIinjKX86U1f2MPSZKpbEWeKOIhojQnWErC5tw==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@bigbluebutton/validate/-/validate-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-lDiOt2L6Ied6Gtjj7pgowquYK4u8rYvRsQ60WMm59BgTR5Dc8vYzcuEYXnxSm/3qeCbqQt+4IL282LyI0/EEOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bigbluebutton/utils": "2.0.0-alpha.21"
+        "@bigbluebutton/utils": "2.0.0-alpha.27"
       }
     },
     "node_modules/@csstools/normalize.css": {
@@ -7368,33 +7395,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/react": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.0.1.tgz",
-      "integrity": "sha512-dSmwJVtJXmku+iocRhWOUFbrERC76TX2Mnf0ATODz8brzAZrMBbzLwQixlBSanZxR6LddK3eiwpSFZgDET1URg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0",
-        "@types/react-dom": "^18.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/@tldraw/core": {
@@ -16649,6 +16649,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -16713,6 +16714,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.3.0",
   "homepage": "/playback/presentation/2.3",
   "dependencies": {
-    "@bigbluebutton/tldraw": "^2.0.0-alpha.25",
+    "@bigbluebutton/tldraw": "^2.0.0-alpha.27",
     "bowser": "^2.11.0",
     "classnames": "^2.3.1",
     "darkreader": "^4.9.46",


### PR DESCRIPTION
https://github.com/bigbluebutton/tldraw/releases/tag/v2.0.0-alpha.27


Staying in sync with
https://github.com/bigbluebutton/bigbluebutton/pull/22659