### PR TITLE
Fix(playback): Support backwards recordings

### DIFF
--- a/src/components/thumbnails/index.js
+++ b/src/components/thumbnails/index.js
@@ -78,7 +78,7 @@ const Thumbnails = ({
 
   const items = useMemo(()=> {
     const thumbnails = storage.thumbnails;
-    const layoutSwap = storage.layoutSwap;
+    const layoutSwap = storage.layoutSwap ?? [];
     const merged = [...thumbnails, ...layoutSwap];
     const sorted = merged.sort((a, b) => a.timestamp - b.timestamp);
     

--- a/src/utils/data/validators.js
+++ b/src/utils/data/validators.js
@@ -169,7 +169,7 @@ function getMostRecentEvent(arr, time) {
 }
 
 const isShowScreenshareAsContent = (data, time) => {
-  if (isEmpty(data)) return false;
+  if (isEmpty(data)) return true;
 
   const event = getMostRecentEvent(data, time);
 


### PR DESCRIPTION
Support Recordings made on 2.7, the issue was caused by the addition of a new file for the recordings the non existence of this file generated a error on thumbnails.