### PR TITLE
fix(tldraw-v2): crash in mobile views

### DIFF
--- a/src/components/tldraw_v2/index.js
+++ b/src/components/tldraw_v2/index.js
@@ -121,6 +121,9 @@ const TldrawPresentationV2 = ({ size }) => {
   }
 
   React.useEffect(() => {
+    if (size.width <= 0 || size.height <= 0) {
+      return;
+    }
     let zoom =
       Math.min(
         svgWidth / viewboxWidth,


### PR DESCRIPTION
When in mobile, the size width is reported as 0, causing a crash in tldraw because of invalid zoom. Abort zoom calculation in those cases.

Fixes https://github.com/bigbluebutton/bigbluebutton/issues/23299