### PR TITLE
fix(quick-swap): prevent duplicated thumbnails

### DIFF
--- a/src/components/thumbnails/index.js
+++ b/src/components/thumbnails/index.js
@@ -34,7 +34,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  handleSearch: () => {},
+  handleSearch: () => { },
   interactive: false,
   search: [],
 };
@@ -76,12 +76,12 @@ const Thumbnails = ({
     }
   });
 
-  const items = useMemo(()=> {
+  const items = useMemo(() => {
     const thumbnails = storage.thumbnails;
     const layoutSwap = storage.layoutSwap ?? [];
     const merged = [...thumbnails, ...layoutSwap];
     const sorted = merged.sort((a, b) => a.timestamp - b.timestamp);
-    
+
     const addThumbsForSwap = sorted.map((item, index, arr) => {
       const previousItem = arr[index - 1];
       const nextItem = arr[index + 1];
@@ -89,16 +89,21 @@ const Thumbnails = ({
         if (!item.showScreenshare) {
           const previousThumbs = arr.slice(0, index)
           const Thumbnail = previousThumbs.find((t) => t.src && t.src !== 'screenshare');
-          return {
-            ...item,
-            src: Thumbnail?.src ?? '',
-            alt: Thumbnail?.alt ?? '',
-          };
+          // don't add if the src is the same as before
+          if (Thumbnail?.src === previousItem?.src) {
+            return null;
+          } else {
+            return {
+              ...item,
+              src: Thumbnail?.src ?? '',
+              alt: Thumbnail?.alt ?? '',
+            };
+          }
         } else if (
-            item.showScreenshare 
-            && (nextItem && nextItem.src !== 'screenshare') 
-            && (previousItem && previousItem.src !== 'screenshare')
-          ) {
+          item.showScreenshare
+          && (nextItem && nextItem.src !== 'screenshare')
+          && (previousItem && previousItem.src !== 'screenshare')
+        ) {
           return {
             ...item,
             src: 'screenshare',
@@ -116,9 +121,9 @@ const Thumbnails = ({
         id: index + 1,
       }
     });
-  
+
     return reworkIds;
-  }, [storage.thumbnails, storage.layoutSwap]);
+  }, []);
 
   const currentIndex = useCurrentIndex(items);
 


### PR DESCRIPTION
- This is to be used with updated code from BBB that correctly generates the thumbnails when screenshare is on for the entire recording. 
- This remove duplicated thumbnails while mantaining the code compatible with previous recordings.