### PR TITLE
feat: render chat messages using messageAsHtml during playback

### DIFF
--- a/src/components/chat/messages/index.scss
+++ b/src/components/chat/messages/index.scss
@@ -4,6 +4,10 @@
   --gray-light-color: var(--gray-light);
   --gray-lightest-color: var(--gray-lightest);
   --highlight-color: var(--blue);
+  --color-text: #111;
+  --color-off-white: #F3F6F9;
+  --color-gray-lightest: #D4D9DF;
+  --color-danger-dark: #AE1010;
 }
 
 .reply-tag {
@@ -18,11 +22,57 @@
 }
 
 .text-vanilla {
-  margin-top: 0.25rem;
-  > * {
+  color: var(--color-text);
+
+  img {
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  p {
+    margin: 0;
+    white-space: pre-wrap;
+  }
+
+  pre:has(code),
+  p code:not(pre > code) {
+    background-color: var(--color-off-white);
+    border: solid 1px var(--color-gray-lightest);
+    border-radius: 4px;
+    padding: 2px;
+    margin: 0;
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+  }
+
+  p code:not(pre > code) {
+    color: var(--color-danger-dark);
+  }
+
+  h1 {
+    font-size: 1.5em;
+    margin: 0;
+  }
+
+  h2 {
+    font-size: 1.3em;
+    margin: 0;
+  }
+
+  h3 {
+    font-size: 1.1em;
+    margin: 0;
+  }
+
+  h4,
+  h5,
+  h6 {
     margin: 0;
   }
 }
+
 
 .user-message-wrapper {
   transition: background-color .5s ease;

--- a/src/components/chat/messages/index.scss
+++ b/src/components/chat/messages/index.scss
@@ -17,6 +17,13 @@
   line-height: 1;
 }
 
+.text-vanilla {
+  margin-top: 0.25rem;
+  > * {
+    margin: 0;
+  }
+}
+
 .user-message-wrapper {
   transition: background-color .5s ease;
 }

--- a/src/components/chat/messages/user/text.js
+++ b/src/components/chat/messages/user/text.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Linkify from 'linkify-react';
-import cx from 'classnames';
 
 const propTypes = {
   active: PropTypes.bool,
@@ -20,20 +18,12 @@ const Text = ({
   hyperlink,
   text,
 }) => {
-  if (hyperlink) {
-    const options = {
-      className: cx('linkified', { inactive: !active }),
-      target: '_blank',
-    };
-
-    return (
-      <Linkify options={options}>
-        {text.replace(/(\S)(https?:\/\/)/g, '$1 $2')}
-      </Linkify>
-    );
-  }
-
-  return <>{text}</>;
+  return (
+    <div
+      className='text-vanilla'
+      dangerouslySetInnerHTML={{ __html: text }}
+    />
+  );
 };
 
 Text.propTypes = propTypes;


### PR DESCRIPTION


### **Description**

This PR implements the **playback integration** for the new `messageAsHtml` field introduced in bigbluebutton/bigbluebutton#24102

Previously, chat messages in recordings were rendered as plain text or Markdown, leading to:

* Broken formatting (e.g., no bold/headers/links)
* Missing link targets (`target="_blank"`, `rel="noopener"`)
* Inconsistent spacing and code block styling compared to the live HTML5 client

With this change, the playback now **renders the preformatted HTML** version of each message, ensuring identical visual and functional behavior to live sessions.

---

### **Changes**

####  Frontend (Playback Chat UI)

* Render `messageAsHtml` using `dangerouslySetInnerHTML`
* Add `.text-vanilla` class to normalize margins for nested elements:

  ```scss
  .text-vanilla {
    margin-top: 0.25rem;
    > * { margin: 0; }
  }
  ```

#### Playback Data

* Read `messageAsHtml` from recording events if present

---

### **Testing Steps**

1. Record a meeting using the latest HTML5 client after https://github.com/bigbluebutton/bigbluebutton/pull/24102.
2. Include messages with:

   * Markdown (`**bold**`, `# headings`)
   * Links (`https://example.com`)
   * Inline code and lists
3. Play back the recording in `bbb-playback`.
4. ✅ Verify:

   * HTML formatting appears correctly (bold, headers, links)
   * Links open in new tab (`target="_blank"`)
   * No excess spacing between elements
   * No XSS or unsafe HTML rendered

---

### **Screenshots (Before / After)**

|                                                   Before                                                  |                                                   After                                                   |
| :-------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------: |
| <img width="318" height="399" alt="image" src="https://github.com/user-attachments/assets/ef288c6b-e47b-4985-b0a1-8976cc3a8c7d" /> | <img width="318" height="399" alt="image" src="https://github.com/user-attachments/assets/b00bc6de-dd93-4d26-80e7-5093d87c080f" />|

---

### **Related PRs / Issues**

* **Core / Client:** [[bigbluebutton/bigbluebutton#24102](https://github.com/bigbluebutton/bigbluebutton/pull/24102)](https://github.com/bigbluebutton/bigbluebutton/pull/24102)
* **Issue:** [[#23857](https://github.com/bigbluebutton/bigbluebutton/issues/23857)](https://github.com/bigbluebutton/bigbluebutton/issues/23857)


