### PR TITLE
feat(whiteboard): make default yellow color more vibrant

### DIFF
--- a/src/components/tldraw_v2/index.js
+++ b/src/components/tldraw_v2/index.js
@@ -18,7 +18,8 @@ import storage from 'utils/data/storage';
 import './index.scss';
 import {
   getTldrawData, getViewBox, createTldrawImageAsset,
-  createTldrawBackgroundShape, createTldrawCursorShape
+  createTldrawBackgroundShape, createTldrawCursorShape,
+  setupColorThemePaletteOverrides
 } from 'utils/tldraw';
 import { buildFileURL } from 'utils/data';
 import { isEmpty } from 'utils/data/validators';
@@ -26,6 +27,8 @@ import getCursor from './cursor';
 
 const MAX_IMAGE_WIDTH = 1440;
 const MAX_IMAGE_HEIGHT = 1080;
+
+setupColorThemePaletteOverrides();
 
 const intlMessages = defineMessages({
   aria: {

--- a/src/utils/tldraw.js
+++ b/src/utils/tldraw.js
@@ -1,4 +1,5 @@
 import storage from 'utils/data/storage';
+import { DefaultColorThemePalette } from '@bigbluebutton/tldraw';
 
 /**
  * Retrieves the BBB version for a specific Tldraw instance from storage.
@@ -160,6 +161,33 @@ const createTldrawCursorShape = (x, y, curPageId) => {
   }
 }
 
+const setupColorThemePaletteOverrides = () => {
+  // Override the default color theme to use our custom palette with more vibrant yellow highlights
+  DefaultColorThemePalette.lightMode.black.highlight = {
+    srgb: '#FFFF00',
+    p3: 'color(display-p3 1 1 0)',
+  };
+  DefaultColorThemePalette.darkMode.black.highlight = {
+    srgb: '#FFFF00',
+    p3: 'color(display-p3 1 1 0)',
+  };
+  // Override the default yellow color to be a more vibrant yellow
+  DefaultColorThemePalette.lightMode.yellow = {
+    solid: '#FFFF00',
+    highlight: {
+      srgb: '#FFFF00',
+      p3: 'color(display-p3 1 1 0)',
+    },
+  };
+  DefaultColorThemePalette.darkMode.yellow = {
+    solid: '#FFFF00',
+    highlight: {
+      srgb: '#FFFF00',
+      p3: 'color(display-p3 1 1 0)',
+    },
+  };
+};
+
 export {
   getTldrawBbbVersion,
   getTldrawData,
@@ -167,4 +195,5 @@ export {
   createTldrawImageAsset,
   createTldrawBackgroundShape,
   createTldrawCursorShape,
+  setupColorThemePaletteOverrides,
 };


### PR DESCRIPTION
### What does this PR do?
Updates the default yellow color to #FFFF00, which is a more vibrant shade, improving visual distinction from the orange color and enhancing overall visibility in drawings and highlights.

<img width="2554" height="1298" alt="Screenshot from 2025-11-11 16-13-22" src="https://github.com/user-attachments/assets/a477d2ef-6003-4a35-bdd9-ad56482b9410" />


Related to: https://github.com/bigbluebutton/bigbluebutton/pull/24165