### PR TITLE
fix(tldraw): use correct tldraw version when there is no shapes

### DIFF
--- a/src/components/tldraw_v2/index.js
+++ b/src/components/tldraw_v2/index.js
@@ -64,6 +64,12 @@ const SlideData = (tldrawAPI) => {
   assets[`slide-background-asset-${id}`] = createTldrawImageAsset(assetId, buildFileURL(src), scaledWidth, scaledHeight)
   shapes["slide-background-shape"] = createTldrawBackgroundShape(assetId, curPageId, scaledWidth, scaledHeight)
 
+  const { x, y } = getCursor(currentCursorIndex);
+
+  if (!(x === -1 || y === -1)) {
+    shapes['cursor'] = createTldrawCursorShape(x, y, curPageId);
+  }
+
   if (index === -1 || isEmpty(interval)) return { assets, shapes, scaleRatio }
 
   for (let i = 0; i < interval.length; i++) {
@@ -79,13 +85,6 @@ const SlideData = (tldrawAPI) => {
       shape.parentId = tldrawAPI?.getCurrentPageId();
       shapes[shape.id] = shape;
     }
-  }
-
-  const camera = tldrawAPI?.getCamera();
-  const { x, y } = getCursor(currentCursorIndex, camera);
-
-  if (!(x === -1 || y === -1)) {
-    shapes['cursor'] = createTldrawCursorShape(x, y, curPageId);
   }
 
   return { assets, shapes, scaleRatio }

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -343,33 +343,36 @@ const buildShapes = result => {
 const buildTldraw = result => {
   if (!result) return [];
 
-  let bbb_version = null;
-  if (result['bbb_version']) {
-    bbb_version = result['bbb_version'];
-    delete result['bbb_version'];
+  const { bbb_version, ...slides } = result;
+
+  if (Object.keys(slides).length === 0) {
+    if (bbb_version) {
+      return [{
+        data: [],
+        bbb_version,
+      }];
+    }
+    return [];
   }
 
-  let tldraw = [];
-  tldraw = Object.keys(result).map(i => {
-    let data = result[i].shapes.map(shape => {
-      return {
-        clear: shape.undo,
-        id: shape.id,
-        shape: shape.shape_data,
-        timestamp: shape.timestamp,
-      }
-    })
+  const tldraw = Object.entries(slides).map(([id, slideData]) => {
+    const data = slideData.shapes.map(shape => ({
+      clear: shape.undo,
+      id: shape.id,
+      shape: shape.shape_data,
+      timestamp: shape.timestamp,
+    }));
 
     return {
       data,
-      timestamp: result[i].timestamp,
-      id: i,
-      bbb_version: bbb_version,
+      timestamp: slideData.timestamp,
+      id,
+      bbb_version,
     };
-  })
+  });
 
   return tldraw;
-}
+};
 
 const buildLayout = result => {
   const { recording } = result;
@@ -473,9 +476,9 @@ const buildChat = result => {
       // Normalize reactions to always be an array
       const reactionsList = chat.reactions ? convertToArray(chat.reactions.reaction) : [];
       const reactions = reactionsList.map((messageReaction) => ({
-          emoji: messageReaction._emoji,
-          count: messageReaction._count,
-        }),
+        emoji: messageReaction._emoji,
+        count: messageReaction._count,
+      }),
       );
       return {
         clear,

--- a/src/utils/tldraw.js
+++ b/src/utils/tldraw.js
@@ -7,7 +7,12 @@ import storage from 'utils/data/storage';
  * @returns {(string|undefined)} The BBB version associated with the Tldraw instance at the specified index. 
  *                               Returns undefined if no instance is found at the index.
  */
-const getTldrawBbbVersion = (index) => storage.tldraw[index]?.bbb_version;
+const getTldrawBbbVersion = (index) => {
+  if (index === -1) {
+    return storage.tldraw[0]?.bbb_version;
+  }
+  return storage.tldraw[index]?.bbb_version;
+};
 
 /**
  * Retrieves Tldraw data for a given slide index and page number.
@@ -98,7 +103,7 @@ const createTldrawImageAsset = (assetId, imageUrl, scaledWidth, scaledHeight) =>
 const createTldrawBackgroundShape = (assetId, curPageId, scaledWidth, scaledHeight) => {
   return {
     x: 1,
-    y: 1, 
+    y: 1,
     rotation: 0,
     isLocked: true,
     opacity: 1,


### PR DESCRIPTION
- Since BBB 3.0, when there is no shapes, there was a bug causing it to use the old tldraw version (v1), leaving the cursor and pan/zoom out of place. 
- This fixes it by setting the version when there is no shapes and also by moving the cursor logic.

How to test: 

1.  do a recording just using pointer and pan/zoom, without adding any shapes.
2. check if cursor and viewed region is correct