### PR TITLE
fix: chat message decoding xml tags unnecessarily

### DIFF
--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -432,21 +432,6 @@ const buildCursor = result => {
   return data;
 };
 
-const clearHyperlink = message => {
-  const regex = /<a href="(.*)" rel="nofollow"><u>\1<\/u><\/a>/g;
-
-  return message.replace(regex, '$1');
-};
-
-const decodeXML = message => {
-  return message
-    .replace(/&(quot|#34);/g, '"')
-    .replace(/&(amp|#38);/g, '&')
-    .replace(/&(apos|#39);/g, "'")
-    .replace(/&(lt|#60);/g, '<')
-    .replace(/&(gt|#62);/g, '>');
-};
-
 const getInitials = name => {
   let initials;
 
@@ -468,7 +453,7 @@ const buildChat = result => {
     const { chattimeline } = popcorn;
     data = convertToArray(chattimeline).map(chat => {
       const clear = chat._out ? parseFloat(chat._out) : -1;
-      const message = decodeXML(clearHyperlink(chat._message));
+      const message = chat._message;
       const initials = getInitials(chat._name);
       const emphasized = chat._chatEmphasizedText === 'true';
       const moderator = chat._senderRole === ROLES.MODERATOR;
@@ -626,7 +611,6 @@ export {
   addAlternatesToThumbnails,
   build,
   buildStyle,
-  decodeXML,
   getAttr,
   getId,
   getNumbers,

--- a/src/utils/builder.test.js
+++ b/src/utils/builder.test.js
@@ -1,6 +1,5 @@
 import {
   buildStyle,
-  decodeXML,
   getAttr,
   getId,
   getNumbers,
@@ -57,33 +56,6 @@ it('builds style object from a string', () => {
   expect(buildStyle(value)).toEqual({});
 });
 
-it('decodes XML predefined entities to character', () => {
-  const entities = {
-    'quot': `"`,
-    '#34': `"`,
-    'amp': `&`,
-    '#38': `&`,
-    'apos': `'`,
-    '#39': `'`,
-    'lt': `<`,
-    '#60': `<`,
-    'gt': `>`,
-    '#62': `>`,
-  };
-
-  for (let entity in entities) {
-    if (Object.prototype.hasOwnProperty.call(entities, entity)) {
-      expect(decodeXML(`&${entity};`)).toEqual(`${entities[entity]}`);
-      expect(decodeXML(` &${entity};`)).toEqual(` ${entities[entity]}`);
-      expect(decodeXML(`&${entity}; `)).toEqual(`${entities[entity]} `);
-      expect(decodeXML(`&${entity};&${entity};`))
-        .toEqual(`${entities[entity]}${entities[entity]}`);
-      expect(decodeXML(`&${entity}; &${entity};`))
-        .toEqual(`${entities[entity]} ${entities[entity]}`);
-    }
-  }
-});
-
 it('gets attributes from a parsed xml node', () => {
   const attr = { first: 1, second: 'two' };
 
@@ -130,4 +102,3 @@ it('gets a numeric array from a string', () => {
   expect(getNumbers(' ')).toEqual([]);
   expect(getNumbers()).toEqual([]);
 });
-


### PR DESCRIPTION
Since https://github.com/bigbluebutton/bbb-playback/pull/314 it's no longer necessary to remove decode xml tags.
It will convert the message wrongly.

`clearHyperlink` is also no longer necessary as the link is generated by akka-apps.