### PR TITLE
fix(infinite-whiteboard): fix background color in Dark Mode

### DIFF
--- a/src/components/bars/top/buttons/theme.js
+++ b/src/components/bars/top/buttons/theme.js
@@ -30,9 +30,9 @@ const css = `
   .tl-image {
     background-color: white !important;
   }
-}
-.tl-background {
-    background-color: #222425 !important;
+  .tl-background {
+    background-color: #F9FAFB !important;
+  }
 }
 `;
 

--- a/src/components/tldraw_v2/index.scss
+++ b/src/components/tldraw_v2/index.scss
@@ -31,4 +31,7 @@
   .tl-image {
     background-color: white !important;
   }
+  .tl-background {
+    background-color: #F9FAFB !important;
+  }
 }


### PR DESCRIPTION
keep infinite whiteboard background color consistent with live meeting and prevent dark mode from affecting drawing visibility. 