### PR TITLE
Add development proxy for testing with remote recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,39 @@ You will be able to play your recordings using the following URL
 https://<domain>/playback/presentation/2.3/<recordId>
 ```
 
+## Development proxy
+
+The development proxy allows you to test the playback player locally against
+recordings hosted on a remote BigBlueButton or Scalelite server (e.g. a
+production instance). This is useful when you want to develop or debug the player
+using real session data without having to download the recording files. It works
+with any publicly accessible recording that is not behind authentication.
+
+The proxy forwards all `/presentation` requests from the local dev server to the
+remote host, avoiding browser CORS restrictions.
+
+Start the dev server with the proxy enabled:
+```
+npm run start:proxy
+```
+
+The script will prompt you for the remote host URL:
+```
+Remote host URL (e.g. https://scalelite.example.com):
+```
+
+Then open the recording in your browser:
+```
+http://localhost:<port>/playback/presentation/2.3/<recordId>
+```
+
+When no URL is provided, the dev server starts normally without any proxy.
+
+> **Note:** The proxy uses `secure: false` so it works with self-signed
+> certificates commonly found on development and staging servers. This setting
+> only affects the local development proxy and has **no impact** on production
+> builds.
+
 ## URL query strings
 
 - frequency:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start:proxy": "bash start-proxy.sh",
     "build": "react-scripts build",
     "test": "react-scripts test"
   },

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,15 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+    const target = process.env.PROXY_HOST;
+    if (!target) return;
+
+    app.use(
+        '/presentation',
+        createProxyMiddleware({
+            target,
+            changeOrigin: true,
+            secure: false,
+        })
+    );
+};

--- a/start-proxy.sh
+++ b/start-proxy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo ""
+echo "BBB Playback - Proxy Dev Server"
+echo "--------------------------------"
+echo ""
+read -p "Remote host URL (e.g. https://scalelite.example.com): " PROXY_HOST
+echo ""
+
+if [ -z "$PROXY_HOST" ]; then
+  echo "No URL provided. Starting without proxy..."
+  echo ""
+  npx react-scripts start
+else
+  echo "Proxy target: $PROXY_HOST"
+  echo ""
+  PROXY_HOST="$PROXY_HOST" npx react-scripts start
+fi


### PR DESCRIPTION
## Summary

Adds a development proxy that allows contributors to test the playback player
locally against recordings hosted on a remote BigBlueButton or Scalelite server.

I've been using this while working on the player and thought it could be useful
for other contributors as well. It removes the need to download recording files
locally — you can just point the dev server at a production instance and test
with real session data.

## What it does

- **[src/setupProxy.js](cci:7://file:///Volumes/External/Gits/OpenSource/bbb-playback/src/setupProxy.js:0:0-0:0)** — CRA development proxy that forwards `/presentation`
  requests to a remote host, bypassing CORS restrictions. Only active when the
  `PROXY_HOST` env variable is set; otherwise the dev server behaves as usual.
- **[start-proxy.sh](cci:7://file:///Volumes/External/Gits/OpenSource/bbb-playback/start-proxy.sh:0:0-0:0)** — Interactive wrapper script that prompts for the remote
  host URL before starting the dev server.
- **[package.json](cci:7://file:///Volumes/External/Gits/OpenSource/bbb-playback/package.json:0:0-0:0)** — Adds a `start:proxy` script.
- **[README.md](cci:7://file:///Volumes/External/Gits/OpenSource/bbb-playback/README.md:0:0-0:0)** — Documents the proxy usage and its purpose.

## Usage
npm run start:proxy

The script prompts for the remote host URL. Once provided, all `/presentation`
requests will be proxied to that host, so the player can fetch recording data
transparently. It works with any publicly accessible recording that is not
behind authentication.

> **Note:** This only works with publicly accessible recordings that are not
> behind authentication. The proxy has no impact on production builds.

