### PR TITLE
fix(dev): Fix crash due to mutation of frozen tldraw objects

### DIFF
--- a/src/components/tldraw/index.js
+++ b/src/components/tldraw/index.js
@@ -102,9 +102,10 @@ const SlideData = (tldrawAPI) => {
       const {
         shape,
       } = tldrawData[i];
-  
-      shape.parentId = tldrawAPI?.currentPageId;
-      shapes[shape.id] = shape; 
+
+      const newShape = { ...shape };
+      newShape.parentId = tldrawAPI?.currentPageId;
+      shapes[newShape.id] = newShape;
     }
   }
 

--- a/src/components/tldraw_v2/index.js
+++ b/src/components/tldraw_v2/index.js
@@ -85,8 +85,9 @@ const SlideData = (tldrawAPI) => {
         shape,
       } = tldrawData[i];
 
-      shape.parentId = tldrawAPI?.getCurrentPageId();
-      shapes[shape.id] = shape;
+      const newShape = { ...shape };
+      newShape.parentId = tldrawAPI?.getCurrentPageId();
+      shapes[newShape.id] = newShape;
     }
   }
 


### PR DESCRIPTION
- When running in development mode (e.g. via proxy), the application crashed with "Cannot assign to read only property 'parentId'". This occurred because the code was directly mutating shape objects from the shared storage, which the Tldraw library freezes in development mode to enforce state immutability. 

- Creates a shallow copy of the shape object before assigning the `parentId` property. This ensures we work with a local mutable instance instead of the processed read-only object, preventing the crash in both v1 and v2 tldraw components.