### PR TITLE
chore: switch font family to Inter from Verdana

### DIFF
--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,8 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
 :root {
   --font-weight-light: 300;
   --font-weight-regular: 400;
   --font-weight-semi-bold: 600;
   --font-weight-bold: 700;
 
-  --font-family: Verdana, Arial, Helvetica, sans-serif;
+  --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }


### PR DESCRIPTION
## Summary
Updates the primary typeface of the playback player to **Inter**. This change replaces the legacy stack (Verdana/Arial) with a modern, high-quality font designed specifically for screen readability. The goal is to provide a **cleaner and more professional appearance** that aligns with modern web standards and significantly improves the overall UI aesthetic.

## What it does
* **CSS / Styles** — Imports the 'Inter' font family via Google Fonts, including weights from 300 to 700.
* **Variable Update** — Updates the `--font-family` root variable to prioritize 'Inter' while maintaining robust system fallbacks (`-apple-system`, `BlinkMacSystemFont`, etc.) for optimal performance.

Note: Inter is a typeface specially crafted for user interfaces, offering better kerning and a more balanced "x-height" than traditional web-safe fonts.