### PR TITLE
feat: persist playback progress per recording in localStorage

### DIFF
--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -101,6 +101,7 @@ const Webcams = () => {
   const tracks = useRef(buildTracks());
   const element = useRef();
   const interval = useRef();
+  const lastProgressSave = useRef(0);
 
   useEffect(() => {
     if (!player.webcams) {
@@ -116,25 +117,33 @@ const Webcams = () => {
             if (player.webcams) {
               const currentTime = player.webcams.currentTime();
               dispatchTimeUpdate(currentTime);
-              // Save progress to localStorage
-              const duration = player.webcams.duration();
-              progress.save(recordId, currentTime, duration);
+              const now = Date.now();
+              if (now - lastProgressSave.current >= progress.SAVE_INTERVAL) {
+                progress.save(recordId, currentTime);
+                lastProgressSave.current = now;
+              }
             }
           }, 1000 / (frequency ? frequency : config.rps));
         });
 
-        player.webcams.on('pause', () => clearInterval(interval.current));
+        player.webcams.on('pause', () => {
+          clearInterval(interval.current);
+          progress.save(recordId, player.webcams.currentTime());
+        });
 
         player.webcams.on('seeked', () => {
           const currentTime = player.webcams.currentTime();
           dispatchTimeUpdate(currentTime);
+          progress.save(recordId, currentTime);
         });
+
+        player.webcams.on('ended', () => progress.clear(recordId));
 
         // Restore position: URL time param takes priority, then localStorage
         player.webcams.on('loadedmetadata', () => {
           const duration = player.webcams.duration();
           const urlTime = getTime();
-          if (urlTime && urlTime < duration) {
+          if (urlTime !== null && urlTime < duration) {
             player.webcams.currentTime(urlTime);
           } else {
             const savedTime = progress.load(recordId);

--- a/src/components/webcams/index.js
+++ b/src/components/webcams/index.js
@@ -16,6 +16,7 @@ import {
   getFrequency,
   getTime,
 } from 'utils/params';
+import progress from 'utils/progress';
 import storage from 'utils/data/storage';
 import player from 'utils/player';
 import './index.scss';
@@ -107,12 +108,17 @@ const Webcams = () => {
       if (!video) return;
 
       player.webcams = videojs(video, buildOptions(sources, tracks), () => {
+        const recordId = storage.metadata.id;
+
         player.webcams.on('play', () => {
           const frequency = getFrequency();
           interval.current = setInterval(() => {
             if (player.webcams) {
               const currentTime = player.webcams.currentTime();
               dispatchTimeUpdate(currentTime);
+              // Save progress to localStorage
+              const duration = player.webcams.duration();
+              progress.save(recordId, currentTime, duration);
             }
           }, 1000 / (frequency ? frequency : config.rps));
         });
@@ -124,15 +130,19 @@ const Webcams = () => {
           dispatchTimeUpdate(currentTime);
         });
 
-        const time = getTime();
-        if (time) {
-          player.webcams.on('loadedmetadata', () => {
-            const duration = player.webcams.duration();
-            if (time < duration) {
-              player.webcams.currentTime(time);
+        // Restore position: URL time param takes priority, then localStorage
+        player.webcams.on('loadedmetadata', () => {
+          const duration = player.webcams.duration();
+          const urlTime = getTime();
+          if (urlTime && urlTime < duration) {
+            player.webcams.currentTime(urlTime);
+          } else {
+            const savedTime = progress.load(recordId);
+            if (savedTime && savedTime < duration) {
+              player.webcams.currentTime(savedTime);
             }
-          });
-        }
+          }
+        });
       });
       logger.debug(ID.WEBCAMS, 'mounted');
     }

--- a/src/utils/progress.js
+++ b/src/utils/progress.js
@@ -5,10 +5,8 @@ const STORAGE_KEY = 'bbb-playback-progress';
 // Minimum seconds before saving (avoid saving at the very start)
 const MIN_TIME = 5;
 
-// Save interval throttle — save at most every N seconds
-const SAVE_INTERVAL = 5;
-
-let lastSaveTime = 0;
+// Milliseconds between periodic saves during playback
+const SAVE_INTERVAL = 5000;
 
 /**
  * Get all saved progress entries from localStorage.
@@ -25,24 +23,15 @@ const getAll = () => {
 
 /**
  * Save the current playback time for a given recording.
- * Throttled to avoid excessive writes.
  */
-const save = (recordId, currentTime, duration) => {
-  if (!recordId || currentTime < MIN_TIME) return;
-
-  const now = Date.now();
-  if (now - lastSaveTime < SAVE_INTERVAL * 1000) return;
-  lastSaveTime = now;
+const save = (recordId, time) => {
+  if (!recordId || time < MIN_TIME) return;
 
   try {
     const entries = getAll();
-    entries[recordId] = {
-      time: currentTime,
-      duration,
-      updatedAt: now,
-    };
+    entries[recordId] = time;
     localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
-    logger.debug('progress: saved', recordId, currentTime.toFixed(1));
+    logger.debug('progress: saved', recordId, time.toFixed(1));
   } catch (e) {
     logger.warn('progress: failed to save', e);
   }
@@ -57,10 +46,10 @@ const load = (recordId) => {
 
   try {
     const entries = getAll();
-    const entry = entries[recordId];
-    if (entry && entry.time > MIN_TIME) {
-      logger.debug('progress: restored', recordId, entry.time.toFixed(1));
-      return entry.time;
+    const time = entries[recordId];
+    if (time > MIN_TIME) {
+      logger.debug('progress: restored', recordId, time.toFixed(1));
+      return time;
     }
   } catch (e) {
     logger.warn('progress: failed to load', e);
@@ -82,4 +71,6 @@ const clear = (recordId) => {
   }
 };
 
-export default { save, load, clear };
+const progress = { save, load, clear, SAVE_INTERVAL };
+
+export default progress;

--- a/src/utils/progress.js
+++ b/src/utils/progress.js
@@ -1,0 +1,85 @@
+import logger from './logger';
+
+const STORAGE_KEY = 'bbb-playback-progress';
+
+// Minimum seconds before saving (avoid saving at the very start)
+const MIN_TIME = 5;
+
+// Save interval throttle — save at most every N seconds
+const SAVE_INTERVAL = 5;
+
+let lastSaveTime = 0;
+
+/**
+ * Get all saved progress entries from localStorage.
+ */
+const getAll = () => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch (e) {
+    logger.warn('progress: failed to read localStorage', e);
+    return {};
+  }
+};
+
+/**
+ * Save the current playback time for a given recording.
+ * Throttled to avoid excessive writes.
+ */
+const save = (recordId, currentTime, duration) => {
+  if (!recordId || currentTime < MIN_TIME) return;
+
+  const now = Date.now();
+  if (now - lastSaveTime < SAVE_INTERVAL * 1000) return;
+  lastSaveTime = now;
+
+  try {
+    const entries = getAll();
+    entries[recordId] = {
+      time: currentTime,
+      duration,
+      updatedAt: now,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    logger.debug('progress: saved', recordId, currentTime.toFixed(1));
+  } catch (e) {
+    logger.warn('progress: failed to save', e);
+  }
+};
+
+/**
+ * Load the saved playback time for a given recording.
+ * Returns the saved time in seconds, or 0 if none found.
+ */
+const load = (recordId) => {
+  if (!recordId) return 0;
+
+  try {
+    const entries = getAll();
+    const entry = entries[recordId];
+    if (entry && entry.time > MIN_TIME) {
+      logger.debug('progress: restored', recordId, entry.time.toFixed(1));
+      return entry.time;
+    }
+  } catch (e) {
+    logger.warn('progress: failed to load', e);
+  }
+
+  return 0;
+};
+
+/**
+ * Clear the saved progress for a given recording.
+ */
+const clear = (recordId) => {
+  try {
+    const entries = getAll();
+    delete entries[recordId];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (e) {
+    logger.warn('progress: failed to clear', e);
+  }
+};
+
+export default { save, load, clear };


### PR DESCRIPTION
## Summary
Adds a feature to **persist playback progress** for each recording using `localStorage`. This allows users to resume watching a recording from where they left off, even after closing the browser or refreshing the page. It provides a more modern and user-friendly experience by remembering the last viewed position automatically.

## What it does
* **src/utils/progress.js** — A new utility module that handles reading, writing, and clearing playback data in `localStorage`. It includes a throttling mechanism to prevent excessive writes and a minimum time threshold to avoid saving progress at the very beginning of a session.
* **src/components/Webcams/index.jsx** — Integrates the progress utility into the player lifecycle. It saves the current time periodically during playback and restores it when the player loads.
* **Logic Priority** — The system follows a specific hierarchy: it first checks for a time parameter in the URL (which takes priority), and if none is present, it attempts to restore the position from `localStorage`.

## Usage
The feature works automatically in the background. 
1. As a user watches a recording, their progress is saved every 5 seconds (if they have watched more than 5 seconds).
2. When the same recording is opened again, the player will automatically seek to the last saved position.
3. If a specific start time is provided via URL (e.g., `?t=10m`), the URL parameter will override the saved progress.

Note: This data is stored locally in the user's browser and is unique to each recording ID. No server-side changes are required.