### PR TITLE
Render pasted whiteboard images in playback

### DIFF
--- a/src/components/notes/index.scss
+++ b/src/components/notes/index.scss
@@ -29,5 +29,10 @@
       padding-left: $padding-extra-small;
       padding-right: $padding;
     }
+
+    img {
+      max-width: 100%;
+      height: auto;
+    }
   }
 }

--- a/src/components/tldraw_v2/index.js
+++ b/src/components/tldraw_v2/index.js
@@ -19,7 +19,7 @@ import './index.scss';
 import {
   getTldrawData, getViewBox, createTldrawImageAsset,
   createTldrawBackgroundShape, createTldrawCursorShape,
-  setupColorThemePaletteOverrides
+  getTldrawImageFilePath, setupColorThemePaletteOverrides
 } from 'utils/tldraw';
 import { buildFileURL } from 'utils/data';
 import { isEmpty } from 'utils/data/validators';
@@ -88,6 +88,16 @@ const SlideData = (tldrawAPI) => {
       const newShape = { ...shape };
       newShape.parentId = tldrawAPI?.getCurrentPageId();
       shapes[newShape.id] = newShape;
+
+      const imageFilePath = getTldrawImageFilePath(newShape);
+      if (imageFilePath) {
+        assets[newShape.props.assetId] = createTldrawImageAsset(
+          newShape.props.assetId,
+          buildFileURL(imageFilePath),
+          newShape.props.w,
+          newShape.props.h,
+        );
+      }
     }
   }
 

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,30 @@
-jest.mock('@bigbluebutton/tldraw', () => ({
-  DefaultColorThemePalette: {
-    lightMode: { black: {}, yellow: {} },
-    darkMode: { black: {}, yellow: {} },
-  },
-}));
+// The whiteboard package ships an ESM bundle that jsdom cannot load, so the whole
+// module is stubbed. Stubs below hold the exports the tests actually rely on; any
+// other export throws on access, so a test that starts using a new symbol fails
+// with its name instead of silently receiving undefined.
+jest.mock('@bigbluebutton/tldraw', () => {
+  const stubs = {
+    // Flags the stub as an ES module so the interop layer hands it over as is:
+    // without it a namespace import copies the known keys into a plain object
+    // and the guard below never runs.
+    __esModule: true,
+    DefaultColorThemePalette: {
+      lightMode: { black: {}, yellow: {} },
+      darkMode: { black: {}, yellow: {} },
+    },
+  };
+
+  // Properties the module interop layer probes before any export is read.
+  const interop = ['__esModule', 'default', 'then'];
+
+  return new Proxy(stubs, {
+    get: (target, property) => {
+      if (property in target) return target[property];
+      if (typeof property === 'symbol' || interop.includes(property)) return undefined;
+
+      throw new Error(
+        `@bigbluebutton/tldraw is mocked and has no "${property}" export. Add it to src/setupTests.js.`
+      );
+    },
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,6 @@
+jest.mock('@bigbluebutton/tldraw', () => ({
+  DefaultColorThemePalette: {
+    lightMode: { black: {}, yellow: {} },
+    darkMode: { black: {}, yellow: {} },
+  },
+}));

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -148,7 +148,7 @@ const buildNotes = result => {
   if (!result) return '';
 
   // Extract the notes' body
-  const regex = /<body>\n.*\n<\/body>/g;
+  const regex = /<body>[\s\S]*<\/body>/g;
   const match = result.match(regex);
 
   let data = '';

--- a/src/utils/tldraw.js
+++ b/src/utils/tldraw.js
@@ -99,6 +99,7 @@ const getTldrawImageFilePath = (shape) => {
   const assetId = shape?.props?.assetId;
 
   if (shape?.type !== 'image' || !src || !assetId) return null;
+  if (typeof src !== 'string') return null;
   if (!TLDRAW_ASSET_ID_PATTERN.test(assetId)) return null;
 
   return src.match(UPLOADED_IMAGE_SRC_PATTERN)?.[1] || null;

--- a/src/utils/tldraw.js
+++ b/src/utils/tldraw.js
@@ -90,6 +90,20 @@ const createTldrawImageAsset = (assetId, imageUrl, scaledWidth, scaledHeight) =>
   };
 }
 
+// Match the published counterpart of the upload path accepted by the whiteboard client.
+const UPLOADED_IMAGE_SRC_PATTERN = /^\/presentation\/[A-Za-z0-9-]+\/(uploads\/[a-f0-9-]+\.(?:png|jpe?g|gif|webp))$/;
+const TLDRAW_ASSET_ID_PATTERN = /^asset:[A-Za-z0-9_-]+$/;
+
+const getTldrawImageFilePath = (shape) => {
+  const src = shape?.meta?.bbbImageSrc;
+  const assetId = shape?.props?.assetId;
+
+  if (shape?.type !== 'image' || !src || !assetId) return null;
+  if (!TLDRAW_ASSET_ID_PATTERN.test(assetId)) return null;
+
+  return src.match(UPLOADED_IMAGE_SRC_PATTERN)?.[1] || null;
+};
+
 /**
  * Creates a background shape object for a Tldraw presentation page. The function generates a shape object 
  * with predefined properties suitable for a background image. It takes the asset ID of the image, the current page ID, 
@@ -208,6 +222,7 @@ export {
   getTldrawData,
   getViewBox,
   createTldrawImageAsset,
+  getTldrawImageFilePath,
   createTldrawBackgroundShape,
   createTldrawCursorShape,
   isTldrawWhiteboard,

--- a/src/utils/tldraw.js
+++ b/src/utils/tldraw.js
@@ -91,7 +91,10 @@ const createTldrawImageAsset = (assetId, imageUrl, scaledWidth, scaledHeight) =>
 }
 
 // Match the published counterpart of the upload path accepted by the whiteboard client.
-const UPLOADED_IMAGE_SRC_PATTERN = /^\/presentation\/[A-Za-z0-9-]+\/(uploads\/[a-f0-9-]+\.(?:png|jpe?g|gif|webp))$/;
+// The file-uploads directory name is part of the recording format.
+// Must match bbb-file-upload, bbb-shared-notes-server, the bbb-file-upload
+// nginx template, the record-and-playback scripts and bbb-presentation-video.
+const UPLOADED_IMAGE_SRC_PATTERN = /^\/presentation\/[A-Za-z0-9-]+\/(file-uploads\/[a-f0-9-]+\.(?:png|jpe?g|gif|webp))$/;
 const TLDRAW_ASSET_ID_PATTERN = /^asset:[A-Za-z0-9_-]+$/;
 
 const getTldrawImageFilePath = (shape) => {

--- a/src/utils/tldraw.test.js
+++ b/src/utils/tldraw.test.js
@@ -3,7 +3,7 @@ import { getTldrawImageFilePath } from './tldraw';
 const validShape = {
   type: 'image',
   meta: {
-    bbbImageSrc: '/presentation/986a45d2a620695c3a0bdca939a8ad4ca6a9e2b9-1785814812863/uploads/44c71706-8566-4c79-a303-79f6862affb0.png',
+    bbbImageSrc: '/presentation/986a45d2a620695c3a0bdca939a8ad4ca6a9e2b9-1785814812863/file-uploads/44c71706-8566-4c79-a303-79f6862affb0.png',
   },
   props: {
     assetId: 'asset:9bXh_4Vm-2',
@@ -12,7 +12,7 @@ const validShape = {
 
 it('gets the uploaded file path from a valid image shape', () => {
   expect(getTldrawImageFilePath(validShape))
-    .toEqual('uploads/44c71706-8566-4c79-a303-79f6862affb0.png');
+    .toEqual('file-uploads/44c71706-8566-4c79-a303-79f6862affb0.png');
 });
 
 it('rejects a non-image shape', () => {

--- a/src/utils/tldraw.test.js
+++ b/src/utils/tldraw.test.js
@@ -1,0 +1,42 @@
+import { getTldrawImageFilePath } from './tldraw';
+
+const validShape = {
+  type: 'image',
+  meta: {
+    bbbImageSrc: '/presentation/986a45d2a620695c3a0bdca939a8ad4ca6a9e2b9-1785814812863/uploads/44c71706-8566-4c79-a303-79f6862affb0.png',
+  },
+  props: {
+    assetId: 'asset:9bXh_4Vm-2',
+  },
+};
+
+it('gets the uploaded file path from a valid image shape', () => {
+  expect(getTldrawImageFilePath(validShape))
+    .toEqual('uploads/44c71706-8566-4c79-a303-79f6862affb0.png');
+});
+
+it('rejects a non-image shape', () => {
+  expect(getTldrawImageFilePath({ ...validShape, type: 'geo' })).toBeNull();
+});
+
+it('rejects an image shape without a source', () => {
+  expect(getTldrawImageFilePath({ ...validShape, meta: {} })).toBeNull();
+});
+
+it('rejects a source outside the uploaded image path', () => {
+  const shape = {
+    ...validShape,
+    meta: { bbbImageSrc: 'https://example.com/image.png' },
+  };
+
+  expect(getTldrawImageFilePath(shape)).toBeNull();
+});
+
+it('rejects a malformed asset id', () => {
+  const shape = {
+    ...validShape,
+    props: { assetId: 'asset:invalid/id' },
+  };
+
+  expect(getTldrawImageFilePath(shape)).toBeNull();
+});

--- a/src/utils/tldraw.test.js
+++ b/src/utils/tldraw.test.js
@@ -40,3 +40,16 @@ it('rejects a malformed asset id', () => {
 
   expect(getTldrawImageFilePath(shape)).toBeNull();
 });
+
+it('rejects an image shape without an asset id', () => {
+  expect(getTldrawImageFilePath({ ...validShape, props: {} })).toBeNull();
+});
+
+it('rejects a non string source', () => {
+  const shape = {
+    ...validShape,
+    meta: { bbbImageSrc: 42 },
+  };
+
+  expect(getTldrawImageFilePath(shape)).toBeNull();
+});


### PR DESCRIPTION
## What changed

Reconstruct tldraw image assets from the validated `bbbImageSrc` stored in recorded image shapes.

The playback now:

- validates the published upload path and tldraw asset ID;
- builds the image URL through `buildFileURL`, preserving relative deployments and `MEDIA_ROOT_URL`;
- creates the asset before creating the recorded shape;
- keeps malformed or unsupported image metadata fail-safe.

A Jest setup mock was also added because the current tldraw dependency loads ESM-only `nanoid` modules that the existing react-scripts test environment cannot parse directly.

## Why

Pasted whiteboard images are recorded as shapes, while their tldraw asset records are intentionally reconstructed by each renderer. The presentation 2.3 playback created the shape without rebuilding its asset, leaving an empty image container.

## Tests

- `CI=true npx react-scripts test`
- 7 test suites passed
- 27 tests passed
- Production build completed
- Deployed and verified against BBB 4.0 desktop presentation playback (2.3); other recording formats and mobile layouts were not checked.

## Evidence

Recording: `986a45d2a620695c3a0bdca939a8ad4ca6a9e2b9-1785814812863`

- Before: the pasted image is visible in chat but missing from the whiteboard.
- After: the `PASTE-IMG 25385` image renders inside the whiteboard.
- DOM verification: the recorded image shape contains `.tl-image` with the expected published upload URL.
- Pasted image visible on the whiteboard - 00:00:26 in the clip.

Before:

![Before: pasted image is missing from the whiteboard](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/cde62b06-a45a-44f3-a73d-eb4723e7f72e/before_t130.png)

After:

![After: pasted image renders on slide 8](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/2454ef15-7416-43bd-8aef-faf8158e879b/after_t130.png)

Animated preview below - click the GIF to open the full-length MP4 with playback controls:

[![Playback: pasted image renders on slide 8](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/18a86374-37c8-4b66-8471-95217ad77cf1/playback.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-08-04/e1a0ad63-c74f-431d-b0a8-211b96b27de1/playback.mp4)

